### PR TITLE
PGB 1237 Split woonadres/briefadres, use nummeraanduiding and adresseerbaar object

### DIFF
--- a/src/gobstuf/stuf/brp/request_template/ingeschrevenpersonen.xml
+++ b/src/gobstuf/stuf/brp/request_template/ingeschrevenpersonen.xml
@@ -31,30 +31,7 @@
                 <BG:inp.bsn>BSN</BG:inp.bsn>
             </BG:gelijk>
             <BG:scope>
-                <BG:object StUF:entiteittype="NPS">
-                    <BG:inp.bsn xsi:nil="true"/>
-                    <BG:geslachtsnaam xsi:nil="true"/>
-                    <BG:voorvoegselGeslachtsnaam xsi:nil="true"/>
-                    <BG:voorletters xsi:nil="true"/>
-                    <BG:voornamen xsi:nil="true"/>
-                    <BG:aanduidingNaamgebruik xsi:nil="true"/>
-                    <BG:geslachtsnaamPartner xsi:nil="true"/>
-                    <BG:geslachtsaanduiding xsi:nil="true"/>
-                    <BG:geboortedatum xsi:nil="true"/>
-                    <BG:overlijdensdatum xsi:nil="true"/>
-                    <BG:verblijfsadres>
-                        <BG:aoa.identificatie xsi:nil="true"/>
-                        <BG:wpl.woonplaatsNaam xsi:nil="true"/>
-                        <BG:gor.straatnaam xsi:nil="true"/>
-                        <BG:aoa.postcode xsi:nil="true"/>
-                        <BG:aoa.huisnummer xsi:nil="true"/>
-                        <BG:aoa.huisletter xsi:nil="true"/>
-                        <BG:aoa.huisnummertoevoeging xsi:nil="true"/>
-                        <BG:inp.locatiebeschrijving xsi:nil="true"/>
-                        <BG:begindatumVerblijf xsi:nil="true"/>
-                    </BG:verblijfsadres>
-                    <BG:inp.gemeenteVanInschrijving xsi:nil="true"/>
-                    <BG:inp.datumInschrijving xsi:nil="true"/>
+                <BG:object StUF:entiteittype="NPS" StUF:scope="alles">
                 </BG:object>
             </BG:scope>
         </BG:npsLv01>

--- a/src/tests/rest/brp/response/test_ingeschrevenpersonen.py
+++ b/src/tests/rest/brp/response/test_ingeschrevenpersonen.py
@@ -6,25 +6,50 @@ from gobstuf.stuf.brp.response.ingeschrevenpersonen import IngeschrevenpersonenS
 
 class TestIngeschrevenpersonenStufResponse(TestCase):
 
+    def empty_mapping(self, mapping):
+        result = {}
+        for k, v in mapping.items():
+            if isinstance(v, dict):
+                result[k] = self.empty_mapping(v)
+            else:
+                result[k] = None
+        return result
+
     def test_get_filtered_object(self):
         res = IngeschrevenpersonenStufResponse(b'<xml></xml>')
 
-        obj = {}
+        obj = self.empty_mapping(IngeschrevenpersonenStufResponse.mapping)
         result = res.get_filtered_object(obj)
         self.assertEqual(result, {})
 
-        obj = {'any key': 'any value'}
+        obj = self.empty_mapping(IngeschrevenpersonenStufResponse.mapping)
+        obj['any key'] = 'any value'
         result = res.get_filtered_object(obj)
-        self.assertEqual(result, obj)
+        self.assertEqual(result, {'any key': 'any value'})
 
+        obj = self.empty_mapping(IngeschrevenpersonenStufResponse.mapping)
+        obj['any key'] = 'any value'
+        obj['overlijdensdatum'] = 'any datum'
         res.inclusiefoverledenpersonen = False
-        obj = {'any key': 'any value', 'overlijdensdatum': 'any datum'}
         result = res.get_filtered_object(obj)
         self.assertEqual(result, None)
 
+        obj = self.empty_mapping(IngeschrevenpersonenStufResponse.mapping)
+        obj['any key'] = 'any value'
+        obj['overlijdensdatum'] = 'any datum'
         res.inclusiefoverledenpersonen = True
         result = res.get_filtered_object(obj)
-        self.assertEqual(result, obj)
+        self.assertEqual(result, {'any key': 'any value', 'overlijdensdatum': 'any datum'})
+
+        obj = self.empty_mapping(IngeschrevenpersonenStufResponse.mapping)
+        obj['verblijfplaats']['woonadres'] = {'any key': 'any value'}
+        result = res.get_filtered_object(obj)
+        self.assertEqual(result, {'verblijfplaats': {'any key': 'any value', 'functieAdres': 'woonadres'}})
+
+        obj = self.empty_mapping(IngeschrevenpersonenStufResponse.mapping)
+        obj['verblijfplaats']['briefadres'] = {'any key': 'any value'}
+        result = res.get_filtered_object(obj)
+        self.assertEqual(result, {'verblijfplaats': {'any key': 'any value', 'functieAdres': 'briefadres'}})
 
     def test_get_links(self):
         res = IngeschrevenpersonenStufResponse(b'<xml></xml>')


### PR DESCRIPTION
Choose verblijfsadres as verblijfplaats, fallbackto correspondentieadres if missing

Include aanduiding adresseerbaar object en nummeraanduiding