### PR TITLE
Use XPath for attribute resolution

### DIFF
--- a/src/gobstuf/stuf/brp/base_response.py
+++ b/src/gobstuf/stuf/brp/base_response.py
@@ -142,6 +142,10 @@ class StufMappedResponse(StufResponse):
         elif mapping and mapping[0] == '=':
             # Literal value, eg: =value results in value
             return mapping[1:]
+        elif mapping and '!' in mapping:
+            # XPath value, eg !.//<element>...
+            mapping, path = mapping.split('!')
+            return self.stuf_message.get_elm_value_by_path(mapping, path, obj)
         elif mapping and '@' in mapping:
             # Element attribute value, eg: element@attribute
             mapping, attr = mapping.split('@')

--- a/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
@@ -35,7 +35,8 @@ class IngeschrevenpersonenStufResponse(StufMappedResponse):
             },
             'woonadres': {
                 'identificatiecodeNummeraanduiding':
-                    'BG:inp.verblijftIn BG:gerelateerde StUF:extraElementen StUF:extraElement',
+                    'BG:inp.verblijftIn BG:gerelateerde StUF:extraElementen' +
+                    '!.//StUF:extraElement[@naam="identificatieNummerAanduiding"]',
                 'identificatiecodeAdresseerbaarObject': 'BG:verblijfsadres BG:aoa.identificatie',
                 'huisletter': 'BG:verblijfsadres BG:aoa.huisletter',
                 'huisnummer': 'BG:verblijfsadres BG:aoa.huisnummer',

--- a/src/gobstuf/stuf/message.py
+++ b/src/gobstuf/stuf/message.py
@@ -76,6 +76,21 @@ class StufMessage:
         if elm is not None:
             return elm.text
 
+    def get_elm_value_by_path(self, elements_str: str, path: str, tree=None):
+        """
+        Get an element by its XPath path
+
+        :param path: XPath spec
+        :param tree: defaults to the message root
+        :return:
+        """
+        elm = self.find_elm(elements_str, tree)
+        if elm is not None:
+            # Find element using XPath expression
+            elm = elm.find(path, self.namespaces)
+            if elm is not None:
+                return elm.text
+
     def get_elm_attr(self, elements_str: str, element_attr: str, tree=None):
         """Get the attribute value for element_attr
 

--- a/src/tests/stuf/brp/test_base_response.py
+++ b/src/tests/stuf/brp/test_base_response.py
@@ -28,7 +28,8 @@ class StufMappedResponseImpl(StufMappedResponse):
         },
         'attr4': (len, 'XML PATH D'),
         'attr5': '=attr5 value',
-        'attr6': 'XML PATH E@ATTR'
+        'attr6': 'XML PATH E@ATTR',
+        'attr7': 'XML PATH F!XPATH EXPRESSION'
     }
 
 
@@ -57,8 +58,15 @@ class StufMappedResponseTest(TestCase):
             },
             'attr4': len(resp.stuf_message.get_elm_value(resp.mapping['attr4'][1])),
             'attr5': 'attr5 value',
-            'attr6': resp.stuf_message.get_elm_attr(resp.mapping['attr6'], 'ATTR')
+            'attr6': resp.stuf_message.get_elm_attr(resp.mapping['attr6'], 'ATTR'),
+            'attr7': 'xpath XPATH EXPRESSION'
         }
+
+    def _mock_stuf_message(self, resp):
+        resp.get_object_elm = MagicMock()
+        resp.stuf_message.get_elm_value = lambda a, o=None: f"value {a}"
+        resp.stuf_message.get_elm_attr = lambda a, attr, o=None: f"attr {attr}"
+        resp.stuf_message.get_elm_value_by_path = lambda a, path, o=None: f"xpath {path}"
 
     def test_get_links(self):
         resp = StufMappedResponseImpl('msg')
@@ -66,16 +74,14 @@ class StufMappedResponseTest(TestCase):
 
     def test_get_mapped_object(self):
         resp = StufMappedResponseImpl('msg')
-        resp.get_object_elm = MagicMock()
-        resp.stuf_message.get_elm_value = lambda a, o=None: f"value {a}"
-        resp.stuf_message.get_elm_attr = lambda a, attr, o=None: f"attr {attr}"
+        self._mock_stuf_message(resp)
 
         result = resp.get_mapped_object()
         self.assertEqual(result, self._get_expected_mapped_result(resp))
 
     def test_get_answer_object(self):
         resp = StufMappedResponseImpl('msg')
-        resp.get_object_elm = MagicMock()
+        self._mock_stuf_message(resp)
 
         result = resp.get_answer_object()
         self.assertEqual(result, self._get_expected_mapped_result(resp))

--- a/src/tests/stuf/test_message.py
+++ b/src/tests/stuf/test_message.py
@@ -135,6 +135,13 @@ class TestXML(TestCase):
   <elm2>
     <elm2sub dummy="dummy value" StUF:attr="ns2 attr">sub value</elm2sub>
   </elm2>
+  <elm3>
+    <elm3sub>
+      <sub x="1">sub1</sub>
+      <sub x="3">sub3</sub>
+      <sub x="2">sub2</sub>
+    </elm3sub>
+  </elm3>
 </root>        
 '''
         stuf = StufMessage(msg)
@@ -165,4 +172,10 @@ class TestXML(TestCase):
 
         # Get an attribute that does not exist
         e = stuf.get_elm_attr('elm1', 'unkown')
+        self.assertEqual(e, None)
+
+        e = stuf.get_elm_value_by_path("elm3", ".//elm3sub//sub[@x='3']")
+        self.assertEqual(e, 'sub3')
+
+        e = stuf.get_elm_value_by_path("elm3", ".//elm3sub//sub[@x='5']")
         self.assertEqual(e, None)


### PR DESCRIPTION
Some attributes require a filter on a collection
for example to get a value from a sublist with a certain attribute value:

```
<StUF:extraElementen>
    <StUF:extraElement naam="identificatieNummerAanduiding">0363200000429356
    </StUF:extraElement>
    <StUF:extraElement naam="officieleStraatnaam">Overamstelstraat</StUF:extraElement>
</StUF:extraElementen>

```
The XPath expression:

-  `.//StUF:extraElement[@naam="identificatieNummerAanduiding"]`

will return the element that matches the given attribute value.