### PR TITLE
Preparation for new ingeschrevenpersonen endpoint

### DIFF
--- a/src/gobstuf/rest/brp/views.py
+++ b/src/gobstuf/rest/brp/views.py
@@ -1,10 +1,10 @@
 from gobstuf.rest.brp.base_view import StufRestView
-from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenStufRequest
+from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenBsnStufRequest
 from gobstuf.stuf.brp.response.ingeschrevenpersonen import IngeschrevenpersonenStufResponse
 
 
-class IngeschrevenpersonenView(StufRestView):
-    request_template = IngeschrevenpersonenStufRequest
+class IngeschrevenpersonenBsnView(StufRestView):
+    request_template = IngeschrevenpersonenBsnStufRequest
     response_template = IngeschrevenpersonenStufResponse
 
     def get_not_found_message(self, **kwargs):

--- a/src/gobstuf/rest/routes.py
+++ b/src/gobstuf/rest/routes.py
@@ -1,5 +1,5 @@
-from gobstuf.rest.brp.views import IngeschrevenpersonenView
+from gobstuf.rest.brp.views import IngeschrevenpersonenBsnView
 
 REST_ROUTES = [
-    ('/brp/ingeschrevenpersonen/<bsn>', IngeschrevenpersonenView.as_view('brp_ingeschrevenpersonen')),
+    ('/brp/ingeschrevenpersonen/<bsn>', IngeschrevenpersonenBsnView.as_view('brp_ingeschrevenpersonen_bsn')),
 ]

--- a/src/gobstuf/stuf/brp/base_request.py
+++ b/src/gobstuf/stuf/brp/base_request.py
@@ -55,10 +55,10 @@ class StufRequest(ABC):
         :param values:
         :return:
         """
-        assert values.keys() == self.replace_paths.keys()  # Should never fail
+        assert values.keys() == self.parameter_paths.keys()  # Should never fail
 
         for key, value in values.items():
-            self.set_element(self.replace_paths[key], value)
+            self.set_element(self.parameter_paths[key], value)
 
     def _load(self):
         """Loads xml template file.
@@ -86,7 +86,16 @@ class StufRequest(ABC):
         return dt.strftime('%Y%m%d%H%M%S%f')[:17]
 
     def set_element(self, path: str, value: str):
+        """Sets element value. Creates element if it doesn't exist
+
+        :param path:
+        :param value:
+        :return:
+        """
         full_path = self.content_root_elm + " " + path
+
+        if self.stuf_message.find_elm(full_path) is None:
+            self.stuf_message.create_elm(full_path)
         self.stuf_message.set_elm_value(full_path, value)
 
     def to_string(self):
@@ -149,7 +158,7 @@ class StufRequest(ABC):
 
     @property
     @abstractmethod
-    def replace_paths(self) -> dict:
+    def parameter_paths(self) -> dict:
         """key -> path pairs, for example:
 
         {'bsn': 'BG:gelijk BG:inp.bsn'}

--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -1,14 +1,14 @@
 from gobstuf.stuf.brp.base_request import StufRequest
 
 
-class IngeschrevenpersonenStufRequest(StufRequest):
+class IngeschrevenpersonenBsnStufRequest(StufRequest):
     template = 'ingeschrevenpersonen.xml'
     content_root_elm = 'soapenv:Body BG:npsLv01'
     soap_action = 'http://www.egem.nl/StUF/sector/bg/0310/npsLv01Integraal'
 
     BSN_LENGTH = 9
 
-    replace_paths = {
+    parameter_paths = {
         'bsn': 'BG:gelijk BG:inp.bsn'
     }
 

--- a/src/gobstuf/stuf/brp/request_template/ingeschrevenpersonen.xml
+++ b/src/gobstuf/stuf/brp/request_template/ingeschrevenpersonen.xml
@@ -28,7 +28,7 @@
                 <StUF:indicatorAantal>false</StUF:indicatorAantal>
             </BG:parameters>
             <BG:gelijk StUF:entiteittype="NPS">
-                <BG:inp.bsn>BSN</BG:inp.bsn>
+                <!-- Parameters are inserted here -->
             </BG:gelijk>
             <BG:scope>
                 <BG:object StUF:entiteittype="NPS" StUF:scope="alles">

--- a/src/gobstuf/stuf/message.py
+++ b/src/gobstuf/stuf/message.py
@@ -65,6 +65,39 @@ class StufMessage:
         elm = self.find_elm(elements_str, tree)
         elm.text = value
 
+    def create_elm(self, elements_str: str, tree=None):
+        """Creates an element when it doesn't exist yet and returns newly created element. If the element already
+        exists, the existing element is returned.
+
+        :param elements_str:
+        :param tree:
+        :return:
+        """
+        elm = self.find_elm(elements_str, tree)
+
+        if elm is not None:
+            # Already exists
+            return elm
+
+        elements = elements_str.split(' ')
+
+        if len(elements) == 1:
+            # Parent is tree
+            parent = tree or self.tree
+        else:
+            # Create parent
+            parent = self.create_elm(' '.join(elements[:-1]), tree)
+
+        create_elm = elements[-1]
+
+        if ':' in create_elm:
+            ns, tag = create_elm.split(':')
+            assert ns in self.namespaces, f"Namespace {ns} not defined"
+
+            return ET.SubElement(parent, f'{{{self.namespaces[ns]}}}{tag}')
+        else:
+            return ET.SubElement(parent, create_elm)
+
     def get_elm_value(self, elements_str: str, tree=None):
         """Get the value of the first element identified by elements_str
 

--- a/src/gobstuf/stuf/message.py
+++ b/src/gobstuf/stuf/message.py
@@ -94,7 +94,8 @@ class StufMessage:
             ns, tag = create_elm.split(':')
             assert ns in self.namespaces, f"Namespace {ns} not defined"
 
-            return ET.SubElement(parent, f'{{{self.namespaces[ns]}}}{tag}')
+            # Add namespaced tag, of the format '{http://example.com/namespace-definition}tag'
+            return ET.SubElement(parent, '{%s}%s' % (self.namespaces[ns], tag))
         else:
             return ET.SubElement(parent, create_elm)
 

--- a/src/tests/rest/brp/request/test_ingeschrevenpersonen.py
+++ b/src/tests/rest/brp/request/test_ingeschrevenpersonen.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
 
-from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenStufRequest
+from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenBsnStufRequest
 
 
 class TestIngeschrevenpersonenStufRequest(TestCase):
 
     def test_validate(self):
-        req = IngeschrevenpersonenStufRequest("gebruiker", "applicatie", {'bsn': 'any bsn'})
+        req = IngeschrevenpersonenBsnStufRequest("gebruiker", "applicatie", {'bsn': 'any bsn'})
 
         for bsn in ['', '12345', '1234567']:
             result = req.validate({'bsn': bsn})

--- a/src/tests/rest/brp/test_views.py
+++ b/src/tests/rest/brp/test_views.py
@@ -2,9 +2,9 @@ from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 from gobstuf.rest.brp.views import (
-    IngeschrevenpersonenView,
+    IngeschrevenpersonenBsnView,
     IngeschrevenpersonenStufResponse,
-    IngeschrevenpersonenStufRequest
+    IngeschrevenpersonenBsnStufRequest
 )
 
 
@@ -12,11 +12,11 @@ class TestIngeschrevenpersonenView(TestCase):
 
     @patch("gobstuf.rest.brp.views.StufRestView", MagicMock())
     def test_templates_set(self):
-        self.assertEqual(IngeschrevenpersonenStufResponse, IngeschrevenpersonenView.response_template)
-        self.assertEqual(IngeschrevenpersonenStufRequest, IngeschrevenpersonenView.request_template)
+        self.assertEqual(IngeschrevenpersonenStufResponse, IngeschrevenpersonenBsnView.response_template)
+        self.assertEqual(IngeschrevenpersonenBsnStufRequest, IngeschrevenpersonenBsnView.request_template)
 
     def test_get_not_found_message(self):
         kwargs = {'bsn': 'BEE ES EN'}
         self.assertEqual('Ingeschreven persoon niet gevonden met burgerservicenummer BEE ES EN.',
-                         IngeschrevenpersonenView().get_not_found_message(**kwargs))
+                         IngeschrevenpersonenBsnView().get_not_found_message(**kwargs))
 

--- a/src/tests/stuf/brp/test_base_request.py
+++ b/src/tests/stuf/brp/test_base_request.py
@@ -9,7 +9,7 @@ from gobstuf.stuf.brp.base_request import StufRequest
 class StufRequestImpl(StufRequest):
     template = 'template.xml'
     content_root_elm = 'A B C'
-    replace_paths = {
+    parameter_paths = {
         'attr1': 'PATH TO ATTR1',
         'attr2': 'PATH TO ATTR2',
     }
@@ -60,9 +60,16 @@ class StufRequestTest(TestCase):
     def test_set_element(self):
         req = StufRequestImpl('', '', {})
         req.stuf_message = MagicMock()
+        req.stuf_message.find_elm.return_value = True
 
         req.set_element('THE PATH', 'the value')
         req.stuf_message.set_elm_value.assert_called_with('A B C THE PATH', 'the value')
+        req.stuf_message.create_elm.assert_not_called()
+
+        # Assert element is created when it doesn't exist
+        req.stuf_message.find_elm.return_value = None
+        req.set_element('THE PATH', 'the value')
+        req.stuf_message.create_elm.assert_called_with('A B C THE PATH')
 
     def test_validate(self):
         # Default validation is to return no errors: None

--- a/src/tests/stuf/test_message.py
+++ b/src/tests/stuf/test_message.py
@@ -126,10 +126,11 @@ class StufMessageTest(TestCase):
         mock_et.tostring.assert_called_with(message.tree)
         self.assertEqual('A\nB\nC', res)
 
+
 class TestXML(TestCase):
 
-    def test_get_elm_attr(self):
-        msg = '''
+    def setUp(self) -> None:
+        self.msg = '''
 <root xmlns:StUF="http://www.egem.nl/StUF/StUF0301">
   <elm1 attr="attr">value</elm1>
   <elm2>
@@ -142,9 +143,12 @@ class TestXML(TestCase):
       <sub x="2">sub2</sub>
     </elm3sub>
   </elm3>
-</root>        
+  <elm4 />
+</root>
 '''
-        stuf = StufMessage(msg)
+
+    def test_get_elm_attr(self):
+        stuf = StufMessage(self.msg)
 
         # Get a root element
         e = stuf.get_elm_value('elm1')
@@ -179,3 +183,22 @@ class TestXML(TestCase):
 
         e = stuf.get_elm_value_by_path("elm3", ".//elm3sub//sub[@x='5']")
         self.assertEqual(e, None)
+
+    def test_create_elm(self):
+        stuf_message = StufMessage(self.msg)
+
+        elm = 'elm4 elm5 elm6'
+
+        stuf_message.create_elm(elm)
+        stuf_message.set_elm_value(elm, 'value of new elm6')
+
+        self.assertEqual('value of new elm6', stuf_message.get_elm_value(elm))
+
+        # Already exists. Original value should be returned
+        stuf_message.create_elm('elm1')
+        self.assertEqual('value', stuf_message.get_elm_value('elm1'))
+
+        # Create element in root
+        stuf_message.create_elm('elm7')
+        stuf_message.set_elm_value('elm7', 'elm7value')
+        self.assertEqual('elm7value', stuf_message.get_elm_value('elm7'))

--- a/src/tests/stuf/test_message.py
+++ b/src/tests/stuf/test_message.py
@@ -193,6 +193,25 @@ class TestXML(TestCase):
         stuf_message.set_elm_value(elm, 'value of new elm6')
 
         self.assertEqual('value of new elm6', stuf_message.get_elm_value(elm))
+        self.assertEqual("""<?xml version="1.0" ?>
+<root xmlns:StUF="http://www.egem.nl/StUF/StUF0301">
+	<elm1 attr="attr">value</elm1>
+	<elm2>
+		<elm2sub StUF:attr="ns2 attr" dummy="dummy value">sub value</elm2sub>
+	</elm2>
+	<elm3>
+		<elm3sub>
+			<sub x="1">sub1</sub>
+			<sub x="3">sub3</sub>
+			<sub x="2">sub2</sub>
+		</elm3sub>
+	</elm3>
+	<elm4>
+		<elm5>
+			<elm6>value of new elm6</elm6>
+		</elm5>
+	</elm4>
+</root>""", stuf_message.pretty_print())
 
         # Already exists. Original value should be returned
         stuf_message.create_elm('elm1')


### PR DESCRIPTION
Add create_elm functionality to StufMessage

Change BaseRequest implementation: Use empty XML template and add the expected paths if they don't exist yet => Makes the templates reusable for different requests.

Change naming existing Ingeschrevenpersonen views and requests to include Bsn to better reflect its use.