### PR TITLE
PGB-1325 Add filter ingeschrevenpersonen endpoint to BRP API

### DIFF
--- a/src/gobstuf/rest/brp/base_view.py
+++ b/src/gobstuf/rest/brp/base_view.py
@@ -21,16 +21,13 @@ def headers_required_decorator(headers):
     :param headers:
     :return:
     """
-
     def headers_required(f):
         def decorator(*args, **kwargs):
             if not all([request.headers.get(h) for h in headers]):
                 return abort(Response(response='Missing required MKS headers', status=400))
 
             return f(*args, **kwargs)
-
         return decorator
-
     return headers_required
 
 
@@ -65,7 +62,15 @@ class StufRestView(MethodView):
         """
         return kwargs
 
-    def _validate(self, **kwargs):
+    def _validate(self, **kwargs) -> dict:
+        """Validates this request. Called before anything else in handling the request.
+
+        Returns the dictionary with errors, or an empty dictionary when no errors occurred.
+        Default behaviour is no validation.
+
+        :param kwargs:
+        :return:
+        """
         return {}
 
     def _get(self, **kwargs):
@@ -201,13 +206,25 @@ class StufRestFilterView(StufRestView):
         return {**kwargs, **self._get_query_parameters()}
 
     def _validate(self, **kwargs):
+        """Validates that a correct combination of query parameters is provided.
+
+        :param kwargs:
+        :return:
+        """
         try:
             self._request_template_parameters(**kwargs)
             return {}
         except self.InvalidQueryParametersException:
             return self._query_parameters_error()
 
-    def _query_parameters_error(self):
+    def _query_parameters_error(self) -> dict:
+        """Returns the error that is returned to the user when the combination of query parameters is not
+        according to specification.
+
+        Provides the possible valid parameter combinations in the error message.
+
+        :return:
+        """
         combinations = ' , '.join([combination
                                    for combination in [
                                        ' / '.join(parameters)

--- a/src/gobstuf/rest/brp/base_view.py
+++ b/src/gobstuf/rest/brp/base_view.py
@@ -5,11 +5,11 @@ from abc import abstractmethod
 
 from gobstuf.certrequest import cert_post
 from gobstuf.stuf.brp.base_request import StufRequest
+from gobstuf.stuf.brp.base_response import StufMappedResponse
 from gobstuf.stuf.exception import NoStufAnswerException
 from gobstuf.stuf.brp.error_response import StufErrorResponse
 from gobstuf.rest.brp.rest_response import RESTResponse
 from gobstuf.config import ROUTE_SCHEME, ROUTE_NETLOC, ROUTE_PATH
-
 
 MKS_USER_HEADER = 'MKS_GEBRUIKER'
 MKS_APPLICATION_HEADER = 'MKS_APPLICATIE'
@@ -21,13 +21,16 @@ def headers_required_decorator(headers):
     :param headers:
     :return:
     """
+
     def headers_required(f):
         def decorator(*args, **kwargs):
             if not all([request.headers.get(h) for h in headers]):
                 return abort(Response(response='Missing required MKS headers', status=400))
 
             return f(*args, **kwargs)
+
         return decorator
+
     return headers_required
 
 
@@ -43,11 +46,27 @@ class StufRestView(MethodView):
     decorators = [headers_required_decorator([MKS_USER_HEADER, MKS_APPLICATION_HEADER])]
 
     def get(self, **kwargs):
+        errors = self._validate(**kwargs)
+
+        if errors:
+            return RESTResponse.bad_request(**errors)
+
         try:
             return self._get(**kwargs)
         except Exception as e:
             print(f"ERROR: Request failed: {str(e)}")
             return RESTResponse.internal_server_error()
+
+    def _request_template_parameters(self, **kwargs):
+        """Return kwargs by default. Childs may override this
+
+        :param kwargs:
+        :return:
+        """
+        return kwargs
+
+    def _validate(self, **kwargs):
+        return {}
 
     def _get(self, **kwargs):
         """kwargs contains the URL parameters, for example {'bsn': xxxx'} when the requested resource is
@@ -61,7 +80,7 @@ class StufRestView(MethodView):
         request_template = self.request_template(
             request.headers.get(MKS_USER_HEADER),
             request.headers.get(MKS_APPLICATION_HEADER),
-            kwargs
+            self._request_template_parameters(**kwargs)
         )
         errors = request_template.validate(kwargs)
         if errors:
@@ -79,6 +98,17 @@ class StufRestView(MethodView):
         # Map MKS response back to REST response.
         response_obj = self.response_template(response.text)
 
+        return self._build_response(response_obj, **kwargs)
+
+    def _build_response(self, response_obj: StufMappedResponse, **kwargs):
+        """Return single object response by default
+
+        Overridden by StufRestFilterView to create a list of objects
+
+        :param response_obj:
+        :param kwargs:
+        :return:
+        """
         try:
             data = response_obj.get_answer_object()
         except NoStufAnswerException:
@@ -144,3 +174,112 @@ class StufRestView(MethodView):
         :return:
         """
         pass  # pragma: no cover
+
+
+class StufRestFilterView(StufRestView):
+    """StufRestFilterView
+
+    A StufRestView that returns a list of objects instead of a single object.
+    Filtering/searching is done with query parameters
+
+    """
+
+    # Define the possible combinations of query parameters in a request. By default the combination of 'no parameters'
+    # is allowed only. First matching combination is returned.
+    query_parameter_combinations = [
+        (),
+    ]
+
+    def _request_template_parameters(self, **kwargs):
+        """Returns the url path variables and query parameters as request template parameters
+
+        Raises an InvalidQueryParametersException. Should call _validate() first.
+
+        :param kwargs:
+        :return:
+        """
+        return {**kwargs, **self._get_query_parameters()}
+
+    def _validate(self, **kwargs):
+        try:
+            self._request_template_parameters(**kwargs)
+            return {}
+        except self.InvalidQueryParametersException:
+            return self._query_parameters_error()
+
+    def _query_parameters_error(self):
+        combinations = ' , '.join([combination
+                                   for combination in [
+                                       ' / '.join(parameters)
+                                       if parameters
+                                       else 'no params'
+                                       for parameters in self.query_parameter_combinations]
+                                   ])
+        return {
+            "title": "De opgegeven combinatie van parameters is niet correct",
+            "detail": f"De mogelijke combinaties zijn: {combinations}",
+            "code": "paramsRequired",
+        }
+
+    def _build_response(self, response_obj: StufMappedResponse, **kwargs):
+        """Returns the REST response, of the format:
+
+        _embedded: {
+            ingeschrevenpersonen: [
+                { response object 1},
+                { response object 2},
+                { ... },
+            ]
+        }
+
+        :param response_obj:
+        :param kwargs:
+        :return:
+        """
+        data = response_obj.get_all_answer_objects()
+        return RESTResponse.ok({
+            '_embedded': {
+                self.name: data,
+            }
+        }, {})
+
+    def _get_query_parameters(self) -> dict:
+        """Returns the query parameters as k:v pairs. Returns only the parameters that are in the first matching
+        combination in query_parameter_combinations.
+
+        Example:
+            query_parameter_combinations = [('a', 'b'), ('a', 'c', 'd'), ()]
+
+            If a, b, c and d are all present and set in the query string, only a and b will be returned, because these
+            form the first match.
+            If b would be missing, a, c and d would be returned.
+            If a were missing an empty dict would be returned. No query parameters is an option in this case, because
+            of the empty tuple.
+            If no match is found an InnvalidQueryParametersException is raised
+
+        :return:
+        """
+        for combination in self.query_parameter_combinations:
+            args = {arg: request.args.get(arg) for arg in combination}
+            if all(args.values()):
+                return args
+
+        raise self.InvalidQueryParametersException()
+
+    def get_not_found_message(self, **kwargs):  # pragma: no cover
+        raise NotImplementedError('Method should never be called')
+
+    @property
+    def name(self):  # pragma: no cover
+        """Return the name of the root element of this collection of objects:
+
+        _embedded: {
+            self.name: []
+        }
+
+        :return:
+        """
+        raise NotImplementedError('Implement this method in the child')
+
+    class InvalidQueryParametersException(Exception):
+        pass

--- a/src/gobstuf/rest/brp/views.py
+++ b/src/gobstuf/rest/brp/views.py
@@ -1,6 +1,19 @@
-from gobstuf.rest.brp.base_view import StufRestView
-from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenBsnStufRequest
+from gobstuf.rest.brp.base_view import StufRestView, StufRestFilterView
+from gobstuf.stuf.brp.request.ingeschrevenpersonen import (
+    IngeschrevenpersonenBsnStufRequest,
+    IngeschrevenpersonenFilterStufRequest
+)
 from gobstuf.stuf.brp.response.ingeschrevenpersonen import IngeschrevenpersonenStufResponse
+
+
+class IngeschrevenpersonenFilterView(StufRestFilterView):
+    request_template = IngeschrevenpersonenFilterStufRequest
+    response_template = IngeschrevenpersonenStufResponse
+    name = 'ingeschrevenpersonen'
+
+    query_parameter_combinations = [
+        ('verblijfplaats__postcode', 'verblijfplaats__huisnummer'),
+    ]
 
 
 class IngeschrevenpersonenBsnView(StufRestView):

--- a/src/gobstuf/rest/routes.py
+++ b/src/gobstuf/rest/routes.py
@@ -1,5 +1,6 @@
-from gobstuf.rest.brp.views import IngeschrevenpersonenBsnView
+from gobstuf.rest.brp.views import IngeschrevenpersonenBsnView, IngeschrevenpersonenFilterView
 
 REST_ROUTES = [
+    ('/brp/ingeschrevenpersonen', IngeschrevenpersonenFilterView.as_view('brp_ingeschrevenpersonen_list')),
     ('/brp/ingeschrevenpersonen/<bsn>', IngeschrevenpersonenBsnView.as_view('brp_ingeschrevenpersonen_bsn')),
 ]

--- a/src/gobstuf/stuf/brp/base_response.py
+++ b/src/gobstuf/stuf/brp/base_response.py
@@ -49,6 +49,15 @@ class StufMappedResponse(StufResponse):
 
         return self.stuf_message.find_elm(self.object_elm, answer_object)
 
+    def get_all_object_elms(self):
+        """Returns all objects from the response message.
+
+        Works like get_object_elm, but does not raise an Exception when there are no results.
+
+        :return:
+        """
+        return self.stuf_message.find_all_elms(self.answer_section + ' ' + self.object_elm)
+
     def get_links(self, data):
         """
         Return the HAL links that correspond with the (self) mapped object
@@ -67,6 +76,8 @@ class StufMappedResponse(StufResponse):
         The response is mapped on the response object
         and then filtered
 
+        If multiple answer objects are present, only the first item is returned.
+
         :return: the object to be returned as answer to the REST call
         :raises: NoStufAnswerException if the object is empty
         """
@@ -77,6 +88,20 @@ class StufMappedResponse(StufResponse):
             raise NoStufAnswerException()
 
         return answer_object
+
+    def get_all_answer_objects(self):
+        """
+        Returns all objects from the StUF response. Works like get_answer_object, but does not raise an Exception when
+        the response is empty.
+
+        :return:
+        """
+        result = []
+        for obj in self.get_all_object_elms():
+            mapped_object = self.get_mapped_object(obj)
+            answer_obj = self.get_filtered_object(mapped_object)
+            result.append(answer_obj)
+        return result
 
     def get_filtered_object(self, mapped_object):
         """

--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -1,11 +1,22 @@
+from abc import ABC
+
 from gobstuf.stuf.brp.base_request import StufRequest
 
 
-class IngeschrevenpersonenBsnStufRequest(StufRequest):
+class IngeschrevenpersonenStufRequest(StufRequest, ABC):
     template = 'ingeschrevenpersonen.xml'
     content_root_elm = 'soapenv:Body BG:npsLv01'
     soap_action = 'http://www.egem.nl/StUF/sector/bg/0310/npsLv01Integraal'
 
+
+class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
+    parameter_paths = {
+        'verblijfplaats__postcode': 'BG:gelijk BG:verblijfsadres BG:aoa.postcode',
+        'verblijfplaats__huisnummer': 'BG:gelijk BG:verblijfsadres BG:aoa.huisnummer',
+    }
+
+
+class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):
     BSN_LENGTH = 9
 
     parameter_paths = {

--- a/src/tests/stuf/brp/test_base_response.py
+++ b/src/tests/stuf/brp/test_base_response.py
@@ -48,6 +48,12 @@ class StufMappedResponseTest(TestCase):
         with self.assertRaises(NoStufAnswerException):
             resp.get_object_elm()
 
+    def test_get_all_object_elms(self):
+        resp = StufMappedResponseImpl('msg')
+        result = resp.get_all_object_elms()
+        self.assertEqual(resp.stuf_message.find_all_elms.return_value, result)
+        resp.stuf_message.find_all_elms.assert_called_with('ANSWER SECTION OBJECT')
+
     def _get_expected_mapped_result(self, resp):
         return {
             'attr1': resp.stuf_message.get_elm_value(resp.mapping['attr1']),
@@ -90,6 +96,16 @@ class StufMappedResponseTest(TestCase):
         resp.get_filtered_object.return_value = None
         with self.assertRaises(NoStufAnswerException):
             result = resp.get_answer_object()
+
+    def test_get_all_answer_objects(self):
+        resp = StufMappedResponseImpl('msg')
+        resp.get_all_object_elms = MagicMock(return_value=['object A', 'object B'])
+        resp.get_mapped_object = lambda x: 'mapped ' + x
+        resp.get_filtered_object = lambda x: 'filtered ' + x
+        self.assertEqual([
+            'filtered mapped object A',
+            'filtered mapped object B',
+        ], resp.get_all_answer_objects())
 
     def test_get_filtered_object(self):
         resp = StufMappedResponseImpl('msg')


### PR DESCRIPTION
First version is the ability to find a person by postcode/huisnummer

Made some small changes to the base classes, but most new functionality is encapsulated in the StufRestFilterView class.

Changes in the existing code:
- StufRestView class has an added _validate method, plus some code is moved into methods so that they can be overridden. No functionality (besides the empty _validate method) is added.
- The BaseResponse class is able to return multiple objects now, using the already existing functionality.