### PR TITLE
PGB-1238 Add expand parameter with validation to BRP Endpoints

### DIFF
--- a/src/gobstuf/rest/brp/views.py
+++ b/src/gobstuf/rest/brp/views.py
@@ -6,7 +6,17 @@ from gobstuf.stuf.brp.request.ingeschrevenpersonen import (
 from gobstuf.stuf.brp.response.ingeschrevenpersonen import IngeschrevenpersonenStufResponse
 
 
-class IngeschrevenpersonenFilterView(StufRestFilterView):
+class IngeschrevenpersonenView:
+    """
+    Contains options that are applicable to all Ingeschrevenpersonen Views
+    Use as first parent class
+    """
+    expand_options = [
+        'partners'
+    ]
+
+
+class IngeschrevenpersonenFilterView(IngeschrevenpersonenView, StufRestFilterView):
     request_template = IngeschrevenpersonenFilterStufRequest
     response_template = IngeschrevenpersonenStufResponse
     response_template_properties = {
@@ -19,7 +29,7 @@ class IngeschrevenpersonenFilterView(StufRestFilterView):
     ]
 
 
-class IngeschrevenpersonenBsnView(StufRestView):
+class IngeschrevenpersonenBsnView(IngeschrevenpersonenView, StufRestView):
     request_template = IngeschrevenpersonenBsnStufRequest
     response_template = IngeschrevenpersonenStufResponse
 


### PR DESCRIPTION
Adds the expand parameter to the brp endpoints. With this PR the expand parameter can be used in the IngeschrevenpersonenStufResponse.

The parameter is validated based on class-based settings.

Also added a technical assertion that the parent _validate() method is always called from the child class for the base views.