### PR TITLE
Accept burgerservicenummer parameter

### DIFF
--- a/src/gobstuf/rest/brp/views.py
+++ b/src/gobstuf/rest/brp/views.py
@@ -25,7 +25,8 @@ class IngeschrevenpersonenFilterView(IngeschrevenpersonenView, StufRestFilterVie
     name = 'ingeschrevenpersonen'
 
     query_parameter_combinations = [
-        ('verblijfplaats__postcode', 'verblijfplaats__huisnummer'),
+        ['burgerservicenummer'],
+        ['verblijfplaats__postcode', 'verblijfplaats__huisnummer'],
     ]
 
 

--- a/src/gobstuf/stuf/brp/base_request.py
+++ b/src/gobstuf/stuf/brp/base_request.py
@@ -55,6 +55,8 @@ class StufRequest(ABC):
         :param values:
         :return:
         """
+        assert set(values.keys()) <= set(self.parameter_paths.keys())
+
         for key, value in values.items():
             self.set_element(self.parameter_paths[key], value)
 

--- a/src/gobstuf/stuf/brp/base_request.py
+++ b/src/gobstuf/stuf/brp/base_request.py
@@ -55,8 +55,6 @@ class StufRequest(ABC):
         :param values:
         :return:
         """
-        assert values.keys() == self.parameter_paths.keys()  # Should never fail
-
         for key, value in values.items():
             self.set_element(self.parameter_paths[key], value)
 

--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -4,16 +4,57 @@ from gobstuf.stuf.brp.base_request import StufRequest
 
 
 class IngeschrevenpersonenStufRequest(StufRequest, ABC):
+    BSN_LENGTH = 9
+
     template = 'ingeschrevenpersonen.xml'
     content_root_elm = 'soapenv:Body BG:npsLv01'
     soap_action = 'http://www.egem.nl/StUF/sector/bg/0310/npsLv01Integraal'
 
+    def validate_bsn(self, bsn):
+        """
+        The BSN should have the correct length, if not return an params error
+
+        :param args:
+        :return:
+        """
+        if len(bsn) != self.BSN_LENGTH:
+            name = "burgerservicenummer"
+            if len(bsn) < self.BSN_LENGTH:
+                invalid_param = {
+                    "code": "minLength",
+                    "reason": f"Waarde is korter dan minimale lengte {self.BSN_LENGTH}."
+                }
+            else:
+                invalid_param = {
+                    "code": "maxLength",
+                    "reason": f"Waarde is langer dan maximale lengte {self.BSN_LENGTH}."
+                }
+            invalid_param['name'] = name
+            return self.params_errors([name], [invalid_param])
+
 
 class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
     parameter_paths = {
+        'burgerservicenummer': 'BG:gelijk BG:inp.bsn',
         'verblijfplaats__postcode': 'BG:gelijk BG:verblijfsadres BG:aoa.postcode',
         'verblijfplaats__huisnummer': 'BG:gelijk BG:verblijfsadres BG:aoa.huisnummer',
     }
+
+    def validate(self, args):
+        """
+        Validate the request arguments
+
+        The BSN should have the correct length, if not return an params error
+
+        :param args:
+        :return:
+        """
+        if args.get('burgerservicenummer'):
+            bsn_error = self.validate_bsn(args['burgerservicenummer'])
+            if bsn_error:
+                return bsn_error
+
+        return super().validate(args)
 
 
 class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):
@@ -32,20 +73,8 @@ class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):
         :param args:
         :return:
         """
-        bsn = args['bsn']
-        if len(bsn) != self.BSN_LENGTH:
-            name = "burgerservicenummer"
-            if len(bsn) < self.BSN_LENGTH:
-                invalid_param = {
-                    "code": "minLength",
-                    "reason": f"Waarde is korter dan minimale lengte {self.BSN_LENGTH}."
-                }
-            else:
-                invalid_param = {
-                    "code": "maxLength",
-                    "reason": f"Waarde is langer dan maximale lengte {self.BSN_LENGTH}."
-                }
-            invalid_param['name'] = name
-            return self.params_errors([name], [invalid_param])
+        bsn_error = self.validate_bsn(args['bsn'])
+        if bsn_error:
+            return bsn_error
 
         return super().validate(args)

--- a/src/tests/stuf/brp/request/test_ingeschrevenpersonen.py
+++ b/src/tests/stuf/brp/request/test_ingeschrevenpersonen.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
-from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenBsnStufRequest
-
+from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenBsnStufRequest, IngeschrevenpersonenFilterStufRequest
 
 class TestIngeschrevenpersonenStufRequest(TestCase):
 
@@ -26,4 +25,25 @@ class TestIngeschrevenpersonenStufRequest(TestCase):
             }])
 
         result = req.validate({'bsn': '123456789'})
+        self.assertEqual(result, None)
+
+        req = IngeschrevenpersonenFilterStufRequest("gebruiker", "applicatie", {'burgerservicenummer': 'any bsn'})
+        for bsn in ['12345', '1234567']:
+            result = req.validate({'burgerservicenummer': bsn})
+            self.assertEqual(result['invalid-params'], [{
+                'code': 'minLength',
+                'reason': f'Waarde is korter dan minimale lengte {req.BSN_LENGTH}.',
+                'name': 'burgerservicenummer'
+            }])
+        self.assertTrue('burgerservicenummer' in result['detail'])
+
+        for bsn in ['1234567890', '12345678901']:
+            result = req.validate({'burgerservicenummer': bsn})
+            self.assertEqual(result['invalid-params'], [{
+                'code': 'maxLength',
+                'reason': f'Waarde is langer dan maximale lengte {req.BSN_LENGTH}.',
+                'name': 'burgerservicenummer'
+            }])
+
+        result = req.validate({'burgerservicenummer': '123456789'})
         self.assertEqual(result, None)


### PR DESCRIPTION
De BRP API is met het burgerservicenummer als path variabele gebouwd, echter deze dient ook als query parameter beschikbaar te zijn.