### PR TITLE
Add functional parameter inclusiefoverledenpersonen

### DIFF
--- a/src/gobstuf/rest/brp/base_view.py
+++ b/src/gobstuf/rest/brp/base_view.py
@@ -42,9 +42,6 @@ class StufRestView(MethodView):
     # Decorator makes sure the MKS headers are set
     decorators = [headers_required_decorator([MKS_USER_HEADER, MKS_APPLICATION_HEADER])]
 
-    # The key/value pairs in this dictionary will be set as properties on the response template object
-    response_template_properties = {}
-
     # Passed to the response template. Values are the default values.
     functional_query_parameters = {
         'expand': None,
@@ -139,8 +136,7 @@ class StufRestView(MethodView):
 
         # Map MKS response back to REST response.
         response_obj = self.response_template(response.text,
-                                              **self._get_functional_query_parameters(),
-                                              **self.response_template_properties)
+                                              **self._get_functional_query_parameters())
 
         return self._build_response(response_obj, **kwargs)
 

--- a/src/gobstuf/rest/brp/views.py
+++ b/src/gobstuf/rest/brp/views.py
@@ -6,7 +6,7 @@ from gobstuf.stuf.brp.request.ingeschrevenpersonen import (
 from gobstuf.stuf.brp.response.ingeschrevenpersonen import IngeschrevenpersonenStufResponse
 
 
-class IngeschrevenpersonenView:
+class IngeschrevenpersonenView(StufRestView):
     """
     Contains options that are applicable to all Ingeschrevenpersonen Views
     Use as first parent class
@@ -15,13 +15,18 @@ class IngeschrevenpersonenView:
         'partners'
     ]
 
+    @property
+    def functional_query_parameters(self):
+        return {
+            **super().functional_query_parameters,
+            'inclusiefoverledenpersonen': False,
+        }
+
 
 class IngeschrevenpersonenFilterView(IngeschrevenpersonenView, StufRestFilterView):
     request_template = IngeschrevenpersonenFilterStufRequest
     response_template = IngeschrevenpersonenStufResponse
-    response_template_properties = {
-        'inclusiefoverledenpersonen': False,
-    }
+
     name = 'ingeschrevenpersonen'
 
     query_parameter_combinations = [
@@ -30,7 +35,7 @@ class IngeschrevenpersonenFilterView(IngeschrevenpersonenView, StufRestFilterVie
     ]
 
 
-class IngeschrevenpersonenBsnView(IngeschrevenpersonenView, StufRestView):
+class IngeschrevenpersonenBsnView(IngeschrevenpersonenView):
     request_template = IngeschrevenpersonenBsnStufRequest
     response_template = IngeschrevenpersonenStufResponse
 

--- a/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
@@ -5,8 +5,5 @@ class IngeschrevenpersonenStufResponse(StufMappedResponse):
     answer_section = 'soapenv:Envelope soapenv:Body BG:npsLa01 BG:antwoord'
     object_elm = 'BG:object'
 
-    # Response parameters. Defaults to True, can be overridden with response_template_properties
-    inclusiefoverledenpersonen = True
-
     # These properties are passed to the filter method of the mapped object
     filter_kwargs = ['inclusiefoverledenpersonen']

--- a/src/tests/rest/brp/test_base_view.py
+++ b/src/tests/rest/brp/test_base_view.py
@@ -240,6 +240,7 @@ class TestStufRestView(TestCase):
         view.request_template.assert_called_with('user', 'application', {'a': 1, 'b': 2})
         view._make_request.assert_called_with(view.request_template.return_value)
 
+        view.response_template.assert_called_with(view._make_request.return_value.text, funcparam=True)
         mock_rest_response.ok.assert_called_with(view.response_template.return_value.get_answer_object.return_value)
 
         # Error response

--- a/src/tests/rest/brp/test_base_view.py
+++ b/src/tests/rest/brp/test_base_view.py
@@ -172,7 +172,7 @@ class TestStufRestView(TestCase):
         self.assertIsNone(getattr(view, '_validate_called', None))
 
         valid_options = ['a', 'b', 'a,b']
-        invalid_options = ['', 'c']
+        invalid_options = ['1', 'c']
 
         for expand in valid_options:
             mock_request.args = {'expand': expand}
@@ -197,6 +197,7 @@ class TestStufRestView(TestCase):
             'd': False,
         }
         view = StufRestView()
+        view._transform_query_parameter_value = lambda x: x
         view.functional_query_parameters = {
             'a': 15,
             'b': 16,

--- a/src/tests/rest/brp/test_base_view.py
+++ b/src/tests/rest/brp/test_base_view.py
@@ -227,9 +227,6 @@ class TestStufRestView(TestCase):
         class StuffRestViewImpl(StufRestView):
             request_template = mock_request_template
             response_template = MagicMock()
-            response_template_properties = {
-                'some_property': 42
-            }
 
         view = StuffRestViewImpl()
         view._make_request = MagicMock()
@@ -243,7 +240,6 @@ class TestStufRestView(TestCase):
         view.request_template.assert_called_with('user', 'application', {'a': 1, 'b': 2})
         view._make_request.assert_called_with(view.request_template.return_value)
 
-        view.response_template.assert_called_with(view._make_request.return_value.text, funcparam=True, some_property=42)
         mock_rest_response.ok.assert_called_with(view.response_template.return_value.get_answer_object.return_value)
 
         # Error response

--- a/src/tests/rest/brp/test_views.py
+++ b/src/tests/rest/brp/test_views.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 from gobstuf.rest.brp.views import (
+    IngeschrevenpersonenView,
     IngeschrevenpersonenBsnView,
     IngeschrevenpersonenFilterView,
     IngeschrevenpersonenStufResponse,
@@ -9,10 +10,16 @@ from gobstuf.rest.brp.views import (
 )
 
 
-class TestIngeschrevernpersonenFilterView(TestCase):
+class TestIngeschrevenpersonenView(TestCase):
+    def test_functional_query_parameters(self):
+        view = IngeschrevenpersonenView()
+
+        self.assertIn('inclusiefoverledenpersonen', view.functional_query_parameters)
+
+
+class TestIngeschrevenpersonenFilterView(TestCase):
     def test_template_properties(self):
         view = IngeschrevenpersonenFilterView()
-        self.assertEqual(False, view.response_template_properties['inclusiefoverledenpersonen'])
 
 
 class TestIngeschrevenpersonenBsnView(TestCase):


### PR DESCRIPTION
Some functions were moved to parent classes to allow for inheritance. The request now accepts ‘inclusiefoverledenpersonen’ as a functional query parameter.