### PR TITLE
Release fix aanhef and aanschrijfwijze

### DIFF
--- a/src/gobstuf/lib/communicatie.py
+++ b/src/gobstuf/lib/communicatie.py
@@ -204,7 +204,11 @@ class Communicatie():
 
         :return:
         """
-        return f"{self._geachte()} {self._naamgebruik(capitalize_eerste_voorvoegsel=True)}"
+        try:
+            return f"{self._geachte()} {self._naamgebruik(capitalize_eerste_voorvoegsel=True)}"
+        except AttributeError:
+            # A required attribute is missing, eg partner name with naamgebruik != eigen
+            pass
 
     @property
     def aanschrijfwijze(self):
@@ -213,7 +217,11 @@ class Communicatie():
 
         :return:
         """
-        return f"{self.persoon.voorletters} {self._naamgebruik(capitalize_eerste_voorvoegsel=False)}"
+        try:
+            return f"{self.persoon.voorletters} {self._naamgebruik(capitalize_eerste_voorvoegsel=False)}"
+        except AttributeError:
+            # A required attribute is missing, eg partner name with naamgebruik != eigen
+            pass
 
     def _get_partner(self):
         """

--- a/src/tests/lib/test_communicatie.py
+++ b/src/tests/lib/test_communicatie.py
@@ -290,6 +290,18 @@ class TestCommunicatie(TestCase):
         with self.assertRaises(NotImplementedError):
             communicatie._geachte()
 
+    def test_naamgebruik_with_missing_partner_data(self):
+        groenen = {
+            'geslachtsaanduiding': 'man',
+            'naam': {
+                'aanduidingNaamgebruik': 'partner_eigen',
+                'geslachtsnaam': 'Groen',
+            }
+        }
+        communicatie = Communicatie(Persoon(groenen))
+        self.assertIsNone(communicatie.aanhef)
+        self.assertIsNone(communicatie.aanschrijfwijze)
+
 
 class TestPersoon(TestCase):
 


### PR DESCRIPTION
When partner data is missing and naamgebruik != eigen
the the aanhef and aanschrijfwijze cannot be bepaald