### PR TITLE
Release throw attribute error on missing naamgebruik

### DIFF
--- a/src/gobstuf/lib/communicatie.py
+++ b/src/gobstuf/lib/communicatie.py
@@ -158,6 +158,10 @@ class Communicatie():
         # GA VV1 GN1 [- VV2 GN2]
         # De waarde van aanduidingNaamgebruik bepaalt hoe de aanhef wordt samengesteld
         # uit de naam van de persoon en de naam van de partner.
+        if not self.persoon.aanduiding_naamgebruik:
+            # Required attribute is missing
+            raise AttributeError
+
         vv1, gn1, vv2, gn2 = {
             AanduidingNaamgebruik.EIGEN: self._eigen_naam,
             AanduidingNaamgebruik.EIGEN_PARTNER: self._eigen_partner_naam,

--- a/src/tests/lib/test_communicatie.py
+++ b/src/tests/lib/test_communicatie.py
@@ -302,6 +302,18 @@ class TestCommunicatie(TestCase):
         self.assertIsNone(communicatie.aanhef)
         self.assertIsNone(communicatie.aanschrijfwijze)
 
+    def test_naamgebruik_with_missing_naamgebruik(self):
+        groenen = {
+            'geslachtsaanduiding': 'man',
+            'naam': {
+                'aanduidingNaamgebruik': None,
+                'geslachtsnaam': 'Groen',
+            }
+        }
+        communicatie = Communicatie(Persoon(groenen))
+        self.assertIsNone(communicatie.aanhef)
+        self.assertIsNone(communicatie.aanschrijfwijze)
+
 
 class TestPersoon(TestCase):
 


### PR DESCRIPTION
If the naamgebruik property is missing
aanhef and aanschrijfwijze are empty