### PR TITLE
Pgb 1241/brp geslachtsnaam geboortedatum

### DIFF
--- a/src/gobstuf/rest/brp/argument_checks.py
+++ b/src/gobstuf/rest/brp/argument_checks.py
@@ -1,0 +1,103 @@
+"""
+Request argument checks are defined here
+
+"""
+import re
+import datetime
+
+
+def validate_date(value: str):
+    try:
+        datetime.datetime.strptime(value, '%Y-%m-%d')
+    except ValueError:
+        return False
+
+    return True
+
+
+class ArgumentCheck():
+
+    is_boolean = {
+        'check': lambda v: v in ['true', 'false'],
+        'msg': {
+            'code': 'boolean',
+            'reason': 'Waarde is geen geldige boolean.'
+        }
+    }
+
+    is_postcode = {
+        'check': lambda v: re.match(r'^[1-9]{1}[0-9]{3}[A-Z]{2}$', v) is not None,
+        'msg': {
+            "code": "pattern",
+            "reason": "Waarde voldoet niet aan patroon ^[1-9]{1}[0-9]{3}[A-Z]{2}$."
+        }
+    }
+
+    is_integer = {
+        'check': lambda v: re.match(r'^\d+$', v) is not None,
+        'msg': {
+            "code": "integer",
+            "reason": "Waarde is geen geldige integer."
+        }
+    }
+
+    is_positive_integer = {
+        'check': lambda v: re.match(r'^[1-9][0-9]*$', v) is not None,
+        'msg': {
+            "code": "minimum",
+            "reason": "Waarde is lager dan minimum 1."
+        }
+    }
+
+    is_valid_date_format = {
+        'check': lambda v: re.match(r'^\d{4}-\d{2}-\d{2}$', v) is not None,
+        'msg': {
+            "code": "invalidFormat",
+            "reason": "Waarde voldoet niet aan het formaat YYYY-MM-DD",
+        }
+    }
+
+    is_valid_date = {
+        'check': validate_date,
+        'msg': {
+            "code": "invalidDate",
+            "reason": "Waarde is geen geldige datum",
+        }
+    }
+
+    @classmethod
+    def has_max_length(cls, max):
+        return {
+            'check': lambda v: len(v) <= max,
+            'msg': {
+                "code": "maxLength",
+                "reason": f"Waarde is langer dan maximale lengte {max}",
+            }
+        }
+
+    @classmethod
+    def has_min_length(cls, min):
+        return {
+            'check': lambda v: len(v) >= min,
+            'msg': {
+                "code": "minLength",
+                "reason": f"Waarde is korter dan minimale lengte {min}",
+            }
+        }
+
+    @classmethod
+    def validate(cls, checks, value):
+        """
+        Validate the given value against one or more checks
+        The first failing check is returned, or None if all checks pass
+
+        :param checks:
+        :param value:
+        :return:
+        """
+        if not isinstance(checks, list):
+            # Accept a single check as value by converting it to a list
+            checks = [checks]
+        for check in checks:
+            if not check['check'](value):
+                return check

--- a/src/gobstuf/rest/brp/base_view.py
+++ b/src/gobstuf/rest/brp/base_view.py
@@ -121,12 +121,13 @@ class StufRestView(MethodView):
         # Request MKS with given request_template
         request_template = self.request_template(
             request.headers.get(MKS_USER_HEADER),
-            request.headers.get(MKS_APPLICATION_HEADER),
-            self._request_template_parameters(**kwargs)
+            request.headers.get(MKS_APPLICATION_HEADER)
         )
         errors = request_template.validate(self._request_template_parameters(**kwargs))
         if errors:
             return RESTResponse.bad_request(**errors)
+
+        request_template.set_values(self._request_template_parameters(**kwargs))
 
         response = self._make_request(request_template)
 

--- a/src/gobstuf/rest/brp/base_view.py
+++ b/src/gobstuf/rest/brp/base_view.py
@@ -1,3 +1,5 @@
+import traceback
+
 from flask.views import MethodView
 from flask import request, abort, Response
 from requests.exceptions import HTTPError
@@ -61,8 +63,9 @@ class StufRestView(MethodView):
 
         try:
             return self._get(**kwargs)
-        except Exception as e:
-            print(f"ERROR: Request failed: {str(e)}")
+        except Exception:
+            print(f"ERROR: Request failed:")
+            traceback.print_exc()
             return RESTResponse.internal_server_error()
 
     def _request_template_parameters(self, **kwargs):

--- a/src/gobstuf/rest/brp/base_view.py
+++ b/src/gobstuf/rest/brp/base_view.py
@@ -12,6 +12,7 @@ from gobstuf.stuf.exception import NoStufAnswerException
 from gobstuf.stuf.brp.error_response import StufErrorResponse
 from gobstuf.rest.brp.rest_response import RESTResponse
 from gobstuf.config import ROUTE_SCHEME, ROUTE_NETLOC, ROUTE_PATH
+from gobstuf.rest.brp.argument_checks import ArgumentCheck
 
 MKS_USER_HEADER = 'MKS_GEBRUIKER'
 MKS_APPLICATION_HEADER = 'MKS_APPLICATIE'
@@ -53,6 +54,7 @@ class StufRestView(MethodView):
     expand_options = []
 
     def get(self, **kwargs):
+
         errors = self._validate(**kwargs)
 
         assert getattr(self, '_validate_called', False), \
@@ -67,6 +69,51 @@ class StufRestView(MethodView):
             print(f"ERROR: Request failed:")
             traceback.print_exc()
             return RESTResponse.internal_server_error()
+
+    def _validate_request_args(self, **kwargs):
+        """
+        Validate the request arguments and path variables
+
+        :param args:
+        :return:
+        """
+        args = self._request_template_parameters(**kwargs)
+        invalid_params = []
+        for arg, value in args.items():
+            invalid_param = self._validate_request_arg(arg, value)
+            if invalid_param:
+                invalid_params.append(invalid_param)
+
+        if invalid_params:
+            param_names = ', '.join([param['name'] for param in invalid_params])
+            return {
+                "invalid-params": invalid_params,
+                "title": "Een of meerdere parameters zijn niet correct.",
+                "detail": f"De foutieve parameter(s) zijn: {param_names}.",
+                "code": "paramsValidation"
+            }
+
+    def _validate_request_arg(self, arg, value):
+        """
+        Validate a request argument
+
+        This is a default implementation. Any subclass can override this method
+        and perform a custom check on any or all request arguments
+
+        :param arg:
+        :param value:
+        :return:
+        """
+        checks = self.request_template.parameter_checks.get(arg)
+
+        if not checks:
+            return
+        error = ArgumentCheck.validate(checks, value)
+        if error:
+            return {
+                'name': arg,
+                **error['msg'],
+            }
 
     def _request_template_parameters(self, **kwargs):
         """Return kwargs by default. Childs may override this
@@ -87,6 +134,12 @@ class StufRestView(MethodView):
         # Control variable to make sure this method is called from child classes
         self._validate_called = True
 
+        # Start with validation of query parameters and path variables
+        invalid_params = self._validate_request_args(**kwargs)
+        if invalid_params:
+            return invalid_params
+
+        # Validate functional query parameters (expand)
         functional_params = self._get_functional_query_parameters()
 
         """
@@ -123,10 +176,6 @@ class StufRestView(MethodView):
             request.headers.get(MKS_USER_HEADER),
             request.headers.get(MKS_APPLICATION_HEADER)
         )
-        errors = request_template.validate(self._request_template_parameters(**kwargs))
-        if errors:
-            return RESTResponse.bad_request(**errors)
-
         request_template.set_values(self._request_template_parameters(**kwargs))
 
         response = self._make_request(request_template)

--- a/src/gobstuf/rest/brp/views.py
+++ b/src/gobstuf/rest/brp/views.py
@@ -32,6 +32,7 @@ class IngeschrevenpersonenFilterView(IngeschrevenpersonenView, StufRestFilterVie
     query_parameter_combinations = [
         ['burgerservicenummer'],
         ['verblijfplaats__postcode', 'verblijfplaats__huisnummer'],
+        ['geboorte__datum', 'naam__geslachtsnaam'],
     ]
 
 

--- a/src/gobstuf/stuf/brp/base_request.py
+++ b/src/gobstuf/stuf/brp/base_request.py
@@ -25,12 +25,11 @@ class StufRequest(ABC):
     tijdstip_bericht_path = 'BG:stuurgegevens StUF:tijdstipBericht'
     referentienummer_path = 'BG:stuurgegevens StUF:referentienummer'
 
-    def __init__(self, gebruiker: str, applicatie: str, values: dict):
+    def __init__(self, gebruiker: str, applicatie: str):
         """
 
         :param gebruiker: MKS gebruiker
         :param applicatie: MKS applicatie
-        :param values: dict with key/values. Key paths are defined in replace_paths
         """
         self.gebruiker = gebruiker
         self.applicatie = applicatie
@@ -40,7 +39,6 @@ class StufRequest(ABC):
 
         self._set_applicatie(applicatie)
         self._set_gebruiker(gebruiker)
-        self._set_values(values)
 
     def _set_applicatie(self, applicatie: str):
         self.set_element(self.applicatie_path, applicatie)
@@ -48,7 +46,7 @@ class StufRequest(ABC):
     def _set_gebruiker(self, gebruiker: str):
         self.set_element(self.gebruiker_path, gebruiker)
 
-    def _set_values(self, values: dict):
+    def set_values(self, values: dict):
         """Sets values in XML. Accepts a dict with {key: value} pairs, where key exists in
         replace_paths and value is the new value of the matching path.
 
@@ -58,7 +56,25 @@ class StufRequest(ABC):
         assert set(values.keys()) <= set(self.parameter_paths.keys())
 
         for key, value in values.items():
-            self.set_element(self.parameter_paths[key], value)
+            self.set_element(self.parameter_paths[key], self._convert_parameter_value(key, value))
+
+    def _convert_parameter_value(self, key: str, value: str):
+        """Converts parameter value for key before injecting the value in the template.
+        Looks for a method convert_param_{KEY} to convert value. If such a method doesn't exist, value is returned
+        without conversion.
+
+        Used, for example for geboorte__datum. The incoming value is of the format YYYY-MM-DD, but this value needs to
+        be converted to the format YYYYMMDD
+
+        :param key:
+        :param value:
+        :return:
+        """
+        convert_func = getattr(self, f'convert_param_{key}', None)
+
+        if callable(convert_func):
+            return convert_func(value)
+        return value
 
     def _load(self):
         """Loads xml template file.

--- a/src/gobstuf/stuf/brp/base_request.py
+++ b/src/gobstuf/stuf/brp/base_request.py
@@ -25,6 +25,8 @@ class StufRequest(ABC):
     tijdstip_bericht_path = 'BG:stuurgegevens StUF:tijdstipBericht'
     referentienummer_path = 'BG:stuurgegevens StUF:referentienummer'
 
+    parameter_checks = {}
+
     def __init__(self, gebruiker: str, applicatie: str):
         """
 
@@ -126,15 +128,6 @@ class StufRequest(ABC):
         self.set_element(self.referentienummer_path, f"GOB{timestr}_{random.randint(0, sys.maxsize)}")
 
         return self.stuf_message.to_string()
-
-    def validate(self, args):
-        """
-        Validate the request arguments. The default implementation is to return no errors (None)
-
-        :param args:
-        :return: None if no errors, else a params error result
-        """
-        return None
 
     def params_errors(self, names, invalid_params):
         """

--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -1,6 +1,12 @@
+import datetime
+import re
+
 from abc import ABC
 
 from gobstuf.stuf.brp.base_request import StufRequest
+
+# Defined at the module level so it's only compiled once
+date_match = re.compile(r'^\d{4}-\d{2}-\d{2}$')
 
 
 class IngeschrevenpersonenStufRequest(StufRequest, ABC):
@@ -10,7 +16,7 @@ class IngeschrevenpersonenStufRequest(StufRequest, ABC):
     content_root_elm = 'soapenv:Body BG:npsLv01'
     soap_action = 'http://www.egem.nl/StUF/sector/bg/0310/npsLv01Integraal'
 
-    def validate_bsn(self, bsn):
+    def validate_bsn(self, bsn, name):
         """
         The BSN should have the correct length, if not return an params error
 
@@ -18,7 +24,6 @@ class IngeschrevenpersonenStufRequest(StufRequest, ABC):
         :return:
         """
         if len(bsn) != self.BSN_LENGTH:
-            name = "burgerservicenummer"
             if len(bsn) < self.BSN_LENGTH:
                 invalid_param = {
                     "code": "minLength",
@@ -38,7 +43,56 @@ class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
         'burgerservicenummer': 'BG:gelijk BG:inp.bsn',
         'verblijfplaats__postcode': 'BG:gelijk BG:verblijfsadres BG:aoa.postcode',
         'verblijfplaats__huisnummer': 'BG:gelijk BG:verblijfsadres BG:aoa.huisnummer',
+        'geboorte__datum': 'BG:gelijk BG:geboortedatum',
+        'naam__geslachtsnaam': 'BG:gelijk BG:geslachtsnaam',
     }
+
+    def convert_param_geboorte__datum(self, value: str):
+        """Transforms the YYYY-MM-DD value to YYYYMMDD
+
+        :param value:
+        :return:
+        """
+        assert date_match.match(value), "This value should already be validated here"
+
+        return value.replace('-', '')
+
+    def validate_date(self, date_str: str, name: str):
+        """Validates a date string:
+        - Should have the format YYYY-MM-DD
+        - Should be valid date
+
+        :param date_str:
+        :return:
+        """
+
+        if not date_match.match(date_str):
+            # This case would also throw a ValueError in the strptime call below, but it's added here to provide a
+            # better error message.
+            return self.params_errors([name], [{
+                "code": "invalidFormat",
+                "reason": "Waarde voldoet niet aan het formaat YYYY-MM-DD",
+                "name": name,
+            }])
+
+        try:
+            datetime.datetime.strptime(date_str, '%Y-%m-%d')
+        except ValueError:
+            return self.params_errors([name], [{
+                "code": "invalidDate",
+                "reason": "Ongeldige datum opgegeven",
+                "name": name,
+            }])
+
+    def validate_geslachtsnaam(self, value: str, name: str):
+        MAX_LENGTH = 200
+
+        if len(value) > MAX_LENGTH:
+            return self.params_errors([name], [{
+                "code": "maxLength",
+                "reason": f"Waarde is langer dan maximale lengte {MAX_LENGTH}",
+                "name": name,
+            }])
 
     def validate(self, args):
         """
@@ -49,10 +103,19 @@ class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
         :param args:
         :return:
         """
-        if args.get('burgerservicenummer'):
-            bsn_error = self.validate_bsn(args['burgerservicenummer'])
-            if bsn_error:
-                return bsn_error
+
+        validations = [
+            ('burgerservicenummer', self.validate_bsn),
+            ('geboorte__datum', self.validate_date),
+            ('naam__geslachtsnaam', self.validate_geslachtsnaam),
+        ]
+
+        # Call the validate methods for each argument. Only if the argument exists.
+        for argument_name, validate_func in validations:
+            if args.get(argument_name):
+                error = validate_func(args[argument_name], argument_name)
+                if error:
+                    return error
 
         return super().validate(args)
 
@@ -73,7 +136,7 @@ class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):
         :param args:
         :return:
         """
-        bsn_error = self.validate_bsn(args['bsn'])
+        bsn_error = self.validate_bsn(args['bsn'], 'burgerservicenummer')
         if bsn_error:
             return bsn_error
 

--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -1,8 +1,8 @@
-import datetime
 import re
 
 from abc import ABC
 
+from gobstuf.rest.brp.argument_checks import ArgumentCheck
 from gobstuf.stuf.brp.base_request import StufRequest
 
 # Defined at the module level so it's only compiled once
@@ -12,30 +12,11 @@ date_match = re.compile(r'^\d{4}-\d{2}-\d{2}$')
 class IngeschrevenpersonenStufRequest(StufRequest, ABC):
     BSN_LENGTH = 9
 
+    bsn_check = [ArgumentCheck.has_min_length(BSN_LENGTH), ArgumentCheck.has_max_length(BSN_LENGTH)]
+
     template = 'ingeschrevenpersonen.xml'
     content_root_elm = 'soapenv:Body BG:npsLv01'
     soap_action = 'http://www.egem.nl/StUF/sector/bg/0310/npsLv01Integraal'
-
-    def validate_bsn(self, bsn, name):
-        """
-        The BSN should have the correct length, if not return an params error
-
-        :param args:
-        :return:
-        """
-        if len(bsn) != self.BSN_LENGTH:
-            if len(bsn) < self.BSN_LENGTH:
-                invalid_param = {
-                    "code": "minLength",
-                    "reason": f"Waarde is korter dan minimale lengte {self.BSN_LENGTH}."
-                }
-            else:
-                invalid_param = {
-                    "code": "maxLength",
-                    "reason": f"Waarde is langer dan maximale lengte {self.BSN_LENGTH}."
-                }
-            invalid_param['name'] = name
-            return self.params_errors([name], [invalid_param])
 
 
 class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
@@ -45,6 +26,15 @@ class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
         'verblijfplaats__huisnummer': 'BG:gelijk BG:verblijfsadres BG:aoa.huisnummer',
         'geboorte__datum': 'BG:gelijk BG:geboortedatum',
         'naam__geslachtsnaam': 'BG:gelijk BG:geslachtsnaam',
+    }
+
+    parameter_checks = {
+        'inclusiefoverledenpersonen': ArgumentCheck.is_boolean,
+        'verblijfplaats__postcode': ArgumentCheck.is_postcode,
+        'verblijfplaats__huisnummer': [ArgumentCheck.is_integer, ArgumentCheck.is_positive_integer],
+        'geboorte__datum': [ArgumentCheck.is_valid_date_format, ArgumentCheck.is_valid_date],
+        'naam__geslachtsnaam': [ArgumentCheck.has_max_length(200)],
+        'burgerservicenummer': IngeschrevenpersonenStufRequest.bsn_check
     }
 
     def convert_param_geboorte__datum(self, value: str):
@@ -57,68 +47,6 @@ class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
 
         return value.replace('-', '')
 
-    def validate_date(self, date_str: str, name: str):
-        """Validates a date string:
-        - Should have the format YYYY-MM-DD
-        - Should be valid date
-
-        :param date_str:
-        :return:
-        """
-
-        if not date_match.match(date_str):
-            # This case would also throw a ValueError in the strptime call below, but it's added here to provide a
-            # better error message.
-            return self.params_errors([name], [{
-                "code": "invalidFormat",
-                "reason": "Waarde voldoet niet aan het formaat YYYY-MM-DD",
-                "name": name,
-            }])
-
-        try:
-            datetime.datetime.strptime(date_str, '%Y-%m-%d')
-        except ValueError:
-            return self.params_errors([name], [{
-                "code": "invalidDate",
-                "reason": "Ongeldige datum opgegeven",
-                "name": name,
-            }])
-
-    def validate_geslachtsnaam(self, value: str, name: str):
-        MAX_LENGTH = 200
-
-        if len(value) > MAX_LENGTH:
-            return self.params_errors([name], [{
-                "code": "maxLength",
-                "reason": f"Waarde is langer dan maximale lengte {MAX_LENGTH}",
-                "name": name,
-            }])
-
-    def validate(self, args):
-        """
-        Validate the request arguments
-
-        The BSN should have the correct length, if not return an params error
-
-        :param args:
-        :return:
-        """
-
-        validations = [
-            ('burgerservicenummer', self.validate_bsn),
-            ('geboorte__datum', self.validate_date),
-            ('naam__geslachtsnaam', self.validate_geslachtsnaam),
-        ]
-
-        # Call the validate methods for each argument. Only if the argument exists.
-        for argument_name, validate_func in validations:
-            if args.get(argument_name):
-                error = validate_func(args[argument_name], argument_name)
-                if error:
-                    return error
-
-        return super().validate(args)
-
 
 class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):
     BSN_LENGTH = 9
@@ -127,17 +55,6 @@ class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):
         'bsn': 'BG:gelijk BG:inp.bsn'
     }
 
-    def validate(self, args):
-        """
-        Validate the request arguments
-
-        The BSN should have the correct length, if not return an params error
-
-        :param args:
-        :return:
-        """
-        bsn_error = self.validate_bsn(args['bsn'], 'burgerservicenummer')
-        if bsn_error:
-            return bsn_error
-
-        return super().validate(args)
+    parameter_checks = {
+        'bsn': IngeschrevenpersonenStufRequest.bsn_check
+    }

--- a/src/gobstuf/stuf/message.py
+++ b/src/gobstuf/stuf/message.py
@@ -166,10 +166,10 @@ class StufMessage:
             return elm.get(element_attr)
 
     def to_string(self):
-        return ET.tostring(self.tree, encoding='unicode')
+        return ET.tostring(self.tree, encoding='utf-8')
 
     def pretty_print(self):
-        xml_string = minidom.parseString(ET.tostring(self.tree)).toprettyxml()
+        xml_string = minidom.parseString(ET.tostring(self.tree, encoding='utf-8')).toprettyxml()
 
         # normalise newlines
         xml_string = os.linesep.join([s for s in xml_string.splitlines() if s.strip()])

--- a/src/tests/rest/brp/test_argument_checks.py
+++ b/src/tests/rest/brp/test_argument_checks.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from gobstuf.rest.brp.argument_checks import ArgumentCheck
+
+class TestArgumentCheck(TestCase):
+
+    def test_validate(self):
+        check = ArgumentCheck.is_boolean
+        for v in ['true', 'false']:
+            self.assertIsNone(ArgumentCheck.validate(check, v))
+        for v in ['True', 'False', 'TRUE', 'FALSE', '', '1', '0', 't', 'f']:
+            self.assertEqual(ArgumentCheck.validate(check, v), check)
+
+        check = ArgumentCheck.is_postcode
+        for v in ['1234AB', '9999XX']:
+            self.assertIsNone(ArgumentCheck.validate(check, v))
+        for v in ['1234ab', '123456', '1234 AB', '']:
+            self.assertEqual(ArgumentCheck.validate(check, v), check)
+
+        check = ArgumentCheck.is_integer
+        for v in ['0', '1']:
+            self.assertIsNone(ArgumentCheck.validate(check, v))
+        for v in ['-1', '', '1.5', 'one']:
+            self.assertEqual(ArgumentCheck.validate(check, v), check)
+
+        check = ArgumentCheck.is_positive_integer
+        for v in ['1', '100']:
+            self.assertIsNone(ArgumentCheck.validate(check, v))
+        for v in ['0', '-1', '', '1.5', 'one']:
+            self.assertEqual(ArgumentCheck.validate(check, v), check)
+
+        check = [ArgumentCheck.is_integer, ArgumentCheck.is_positive_integer]
+        for v in ['1', '100']:
+            self.assertIsNone(ArgumentCheck.validate(check, v))
+        for v in ['-1', '', '1.5', 'one']:
+            self.assertEqual(ArgumentCheck.validate(check, v), ArgumentCheck.is_integer)
+        for v in ['0']:
+            self.assertEqual(ArgumentCheck.validate(check, v), ArgumentCheck.is_positive_integer)
+
+        check = ArgumentCheck.is_valid_date_format
+        self.assertIsNone(ArgumentCheck.validate(check, '2020-05-28'))
+
+        check = ArgumentCheck.is_valid_date
+        self.assertIsNone(ArgumentCheck.validate(check, '2020-02-28'))
+        self.assertTrue(ArgumentCheck.validate(check, '2020-02-30'))
+
+        check = ArgumentCheck.has_min_length(20)
+        for v in [19*'a', '', 'a', 'aaa']:
+            self.assertEqual(ArgumentCheck.validate(check, v), check)
+        for v in [20*'a', 100*'a', 21*'a']:
+            self.assertIsNone(ArgumentCheck.validate(check, v))
+
+        check = ArgumentCheck.has_max_length(20)
+        for v in [20*'a', '', 5*'a', 'jkaldjf']:
+            self.assertIsNone(ArgumentCheck.validate(check, v))
+        for v in [21*'a', 100*'a']:
+            self.assertEqual(ArgumentCheck.validate(check, v), check)

--- a/src/tests/rest/brp/test_base_view.py
+++ b/src/tests/rest/brp/test_base_view.py
@@ -115,6 +115,7 @@ class TestStufRestView(TestCase):
 
         # Naughty child does not call super()._validate() and raises an error
         naughty_child = StufRestViewNaughtyChild()
+        naughty_child._validate_request_args = MagicMock(return_value=None)
 
         kwargs = {'kw': 'arg'}
         with self.assertRaises(AssertionError):
@@ -122,6 +123,7 @@ class TestStufRestView(TestCase):
 
         # Obedient child does call super()._validate() and succeeds
         obedient_child = StufRestViewObedientChild()
+        obedient_child._validate_request_args = MagicMock(return_value=None)
 
         self.assertEqual('OK', obedient_child.get(**kwargs))
 
@@ -168,6 +170,7 @@ class TestStufRestView(TestCase):
     @patch("gobstuf.rest.brp.base_view.request")
     def test_validate(self, mock_request):
         view = StufRestView()
+        view._validate_request_args = MagicMock(return_value=None)
         view.expand_options = ['a', 'b']
         self.assertIsNone(getattr(view, '_validate_called', None))
 
@@ -187,6 +190,13 @@ class TestStufRestView(TestCase):
         for expand in invalid_options:
             mock_request.args = {'expand': expand}
             self.assertEqual(error, view._validate())
+
+    def test_validate_call_request_args(self):
+        view = StufRestView()
+        view._validate_request_args = MagicMock(return_value={'the': 'errors'})
+
+        self.assertEqual({'the': 'errors'}, view._validate(kw='arg'))
+        view._validate_request_args.assert_called_with(kw='arg')
 
     @patch("gobstuf.rest.brp.base_view.request")
     def test_get_functional_query_parameters(self, mock_request):
@@ -222,7 +232,6 @@ class TestStufRestView(TestCase):
         mock_request.args = {}
 
         mock_request_template = MagicMock()
-        mock_request_template.return_value.validate.return_value = None
 
         class StuffRestViewImpl(StufRestView):
             request_template = mock_request_template
@@ -257,12 +266,6 @@ class TestStufRestView(TestCase):
 
         self.assertEqual(mock_rest_response.not_found(), view._get(a=1, b=2))
 
-        # 400 Bad Request
-        mock_request_template.return_value.validate.return_value = {'error': 'any error', 'code': 'any code'}
-        view._bad_request_response = MagicMock()
-        self.assertEqual(mock_rest_response.bad_request.return_value, view._get(a=1, b=2))
-        mock_rest_response.bad_request.assert_called_with(error='any error', code='any code')
-
         # Test invalid request
         view._validate = lambda **kwargs: {'some': 'error'}
         kwargs = {'kw': 'args'}
@@ -276,6 +279,7 @@ class TestStufRestView(TestCase):
         view._validate = MagicMock(return_value={})
         view._get_functional_query_parameters = MagicMock(return_value={})
         view._validate_called = True
+        view._validate_request_args = MagicMock(return_value=None)
 
         # Regular response
         result = view.get(any='thing')
@@ -409,4 +413,56 @@ class TestStufRestFilterView(TestCase):
 
         with self.assertRaises(view.InvalidQueryParametersException):
             view._get_query_parameters()
+
+    @patch("gobstuf.rest.brp.base_view.RESTResponse")
+    def test_argument_check(self, mock_rest_response):
+        view = StufRestView()
+        view._validate_request_args = MagicMock(return_value={'error': 'any error'})
+        self.assertEqual(view.get(), mock_rest_response.bad_request.return_value)
+        mock_rest_response.bad_request.assert_called_with(error='any error')
+
+    @patch("gobstuf.rest.brp.base_view.request")
+    def test_validate_request_args(self, mock_request):
+        class StufRestViewImpl(StufRestView):
+            request_template = MagicMock()
+
+        view = StufRestViewImpl()
+        view._request_template_parameters = MagicMock(return_value={
+            'attr1': 'value1',
+            'attr2': 'value2',
+            'attr3': 'value3',
+            'attr4': 'value4',
+        })
+
+        view.request_template.parameter_checks = {
+            'attr1': {
+                'check': lambda v: False,
+                'msg': {
+                    'the msg': 'oh oh',
+                }
+            },
+            'attr2': {
+                'check': lambda v: True,
+                'msg': {
+                    'the msg': 'this one will not be shown',
+                }
+            },
+            'attr4': {
+                'check': lambda v: False,
+                'msg': {
+                    'the msg': 'foute boel',
+                }
+            }
+        }
+
+        self.assertEqual({
+            'invalid-params': [
+                {'name': 'attr1', 'the msg': 'oh oh'},
+                {'name': 'attr4', 'the msg': 'foute boel'},
+            ],
+            'title': 'Een of meerdere parameters zijn niet correct.',
+            'detail': 'De foutieve parameter(s) zijn: attr1, attr4.',
+            'code': 'paramsValidation',
+        }, view._validate_request_args(some='kwargs'))
+        view._request_template_parameters.assert_called_with(some='kwargs')
 

--- a/src/tests/rest/brp/test_base_view.py
+++ b/src/tests/rest/brp/test_base_view.py
@@ -237,7 +237,8 @@ class TestStufRestView(TestCase):
 
         # Success response
         self.assertEqual(mock_rest_response.ok.return_value, view._get(a=1, b=2))
-        view.request_template.assert_called_with('user', 'application', {'a': 1, 'b': 2})
+        view.request_template.assert_called_with('user', 'application')
+        view.request_template.return_value.set_values.assert_called_with({'a': 1, 'b': 2})
         view._make_request.assert_called_with(view.request_template.return_value)
 
         view.response_template.assert_called_with(view._make_request.return_value.text, funcparam=True)

--- a/src/tests/stuf/brp/request/test_ingeschrevenpersonen.py
+++ b/src/tests/stuf/brp/request/test_ingeschrevenpersonen.py
@@ -1,54 +1,6 @@
 from unittest import TestCase
 
-from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenBsnStufRequest, IngeschrevenpersonenFilterStufRequest
-
-class TestIngeschrevenpersonenStufRequest(TestCase):
-
-    def test_validate(self):
-        req = IngeschrevenpersonenBsnStufRequest("gebruiker", "applicatie")
-        req.set_values({'bsn': 'any bsn'})
-
-        for bsn in ['', '12345', '1234567']:
-            result = req.validate({'bsn': bsn})
-            self.assertEqual(result['invalid-params'], [{
-                'code': 'minLength',
-                'reason': f'Waarde is korter dan minimale lengte {req.BSN_LENGTH}.',
-                'name': 'burgerservicenummer'
-            }])
-        self.assertTrue('burgerservicenummer' in result['detail'])
-
-        for bsn in ['1234567890', '12345678901']:
-            result = req.validate({'bsn': bsn})
-            self.assertEqual(result['invalid-params'], [{
-                'code': 'maxLength',
-                'reason': f'Waarde is langer dan maximale lengte {req.BSN_LENGTH}.',
-                'name': 'burgerservicenummer'
-            }])
-
-        result = req.validate({'bsn': '123456789'})
-        self.assertEqual(result, None)
-
-        req = IngeschrevenpersonenFilterStufRequest("gebruiker", "applicatie")
-        req.set_values({'burgerservicenummer': 'any bsn'})
-        for bsn in ['12345', '1234567']:
-            result = req.validate({'burgerservicenummer': bsn})
-            self.assertEqual(result['invalid-params'], [{
-                'code': 'minLength',
-                'reason': f'Waarde is korter dan minimale lengte {req.BSN_LENGTH}.',
-                'name': 'burgerservicenummer'
-            }])
-        self.assertTrue('burgerservicenummer' in result['detail'])
-
-        for bsn in ['1234567890', '12345678901']:
-            result = req.validate({'burgerservicenummer': bsn})
-            self.assertEqual(result['invalid-params'], [{
-                'code': 'maxLength',
-                'reason': f'Waarde is langer dan maximale lengte {req.BSN_LENGTH}.',
-                'name': 'burgerservicenummer'
-            }])
-
-        result = req.validate({'burgerservicenummer': '123456789'})
-        self.assertEqual(result, None)
+from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenFilterStufRequest
 
 
 class TestIngeschrevenPersonenFilterStufRequest(TestCase):
@@ -61,34 +13,34 @@ class TestIngeschrevenPersonenFilterStufRequest(TestCase):
         with self.assertRaises(AssertionError):
             request.convert_param_geboorte__datum('INVALID')
 
-    def test_validate(self):
-        request = IngeschrevenpersonenFilterStufRequest('gebruiker', 'applicatie')
-
-        result = request.validate({'geboorte__datum': '2000-02-28'})
-        self.assertIsNone(result)
-
-        result = request.validate({'geboorte__datum': '2000-02-30'})
-        self.assertEqual(result['invalid-params'], [{
-            'code': 'invalidDate',
-            'reason': 'Ongeldige datum opgegeven',
-            'name': 'geboorte__datum'
-        }])
-
-        result = request.validate({'geboorte__datum': '2000-0229'})
-        self.assertEqual(result['invalid-params'], [{
-            'code': 'invalidFormat',
-            'reason': 'Waarde voldoet niet aan het formaat YYYY-MM-DD',
-            'name': 'geboorte__datum'
-        }])
-
-        result = request.validate({'naam__geslachtsnaam': 'Gage'})
-        self.assertIsNone(result)
-
-        result = request.validate({'naam__geslachtsnaam': 'Mannix' * 100})
-        self.assertEqual(result['invalid-params'], [{
-            'code': 'maxLength',
-            'reason': 'Waarde is langer dan maximale lengte 200',
-            'name': 'naam__geslachtsnaam',
-        }])
-
-
+    # def test_validate(self):
+    #     request = IngeschrevenpersonenFilterStufRequest('gebruiker', 'applicatie')
+    #
+    #     result = request.validate({'geboorte__datum': '2000-02-28'})
+    #     self.assertIsNone(result)
+    #
+    #     result = request.validate({'geboorte__datum': '2000-02-30'})
+    #     self.assertEqual(result['invalid-params'], [{
+    #         'code': 'invalidDate',
+    #         'reason': 'Ongeldige datum opgegeven',
+    #         'name': 'geboorte__datum'
+    #     }])
+    #
+    #     result = request.validate({'geboorte__datum': '2000-0229'})
+    #     self.assertEqual(result['invalid-params'], [{
+    #         'code': 'invalidFormat',
+    #         'reason': 'Waarde voldoet niet aan het formaat YYYY-MM-DD',
+    #         'name': 'geboorte__datum'
+    #     }])
+    #
+    #     result = request.validate({'naam__geslachtsnaam': 'Gage'})
+    #     self.assertIsNone(result)
+    #
+    #     result = request.validate({'naam__geslachtsnaam': 'Mannix' * 100})
+    #     self.assertEqual(result['invalid-params'], [{
+    #         'code': 'maxLength',
+    #         'reason': 'Waarde is langer dan maximale lengte 200',
+    #         'name': 'naam__geslachtsnaam',
+    #     }])
+    #
+    #

--- a/src/tests/stuf/brp/request/test_ingeschrevenpersonen.py
+++ b/src/tests/stuf/brp/request/test_ingeschrevenpersonen.py
@@ -5,7 +5,8 @@ from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenBs
 class TestIngeschrevenpersonenStufRequest(TestCase):
 
     def test_validate(self):
-        req = IngeschrevenpersonenBsnStufRequest("gebruiker", "applicatie", {'bsn': 'any bsn'})
+        req = IngeschrevenpersonenBsnStufRequest("gebruiker", "applicatie")
+        req.set_values({'bsn': 'any bsn'})
 
         for bsn in ['', '12345', '1234567']:
             result = req.validate({'bsn': bsn})
@@ -27,7 +28,8 @@ class TestIngeschrevenpersonenStufRequest(TestCase):
         result = req.validate({'bsn': '123456789'})
         self.assertEqual(result, None)
 
-        req = IngeschrevenpersonenFilterStufRequest("gebruiker", "applicatie", {'burgerservicenummer': 'any bsn'})
+        req = IngeschrevenpersonenFilterStufRequest("gebruiker", "applicatie")
+        req.set_values({'burgerservicenummer': 'any bsn'})
         for bsn in ['12345', '1234567']:
             result = req.validate({'burgerservicenummer': bsn})
             self.assertEqual(result['invalid-params'], [{
@@ -47,3 +49,46 @@ class TestIngeschrevenpersonenStufRequest(TestCase):
 
         result = req.validate({'burgerservicenummer': '123456789'})
         self.assertEqual(result, None)
+
+
+class TestIngeschrevenPersonenFilterStufRequest(TestCase):
+
+    def test_convert_param_geboorte__datum(self):
+        request = IngeschrevenpersonenFilterStufRequest('gebruiker', 'applicatie')
+
+        self.assertEqual('20200528', request.convert_param_geboorte__datum('2020-05-28'))
+
+        with self.assertRaises(AssertionError):
+            request.convert_param_geboorte__datum('INVALID')
+
+    def test_validate(self):
+        request = IngeschrevenpersonenFilterStufRequest('gebruiker', 'applicatie')
+
+        result = request.validate({'geboorte__datum': '2000-02-28'})
+        self.assertIsNone(result)
+
+        result = request.validate({'geboorte__datum': '2000-02-30'})
+        self.assertEqual(result['invalid-params'], [{
+            'code': 'invalidDate',
+            'reason': 'Ongeldige datum opgegeven',
+            'name': 'geboorte__datum'
+        }])
+
+        result = request.validate({'geboorte__datum': '2000-0229'})
+        self.assertEqual(result['invalid-params'], [{
+            'code': 'invalidFormat',
+            'reason': 'Waarde voldoet niet aan het formaat YYYY-MM-DD',
+            'name': 'geboorte__datum'
+        }])
+
+        result = request.validate({'naam__geslachtsnaam': 'Gage'})
+        self.assertIsNone(result)
+
+        result = request.validate({'naam__geslachtsnaam': 'Mannix' * 100})
+        self.assertEqual(result['invalid-params'], [{
+            'code': 'maxLength',
+            'reason': 'Waarde is langer dan maximale lengte 200',
+            'name': 'naam__geslachtsnaam',
+        }])
+
+

--- a/src/tests/stuf/brp/test_base_request.py
+++ b/src/tests/stuf/brp/test_base_request.py
@@ -75,11 +75,6 @@ class StufRequestTest(TestCase):
         req.set_element('THE PATH', 'the value')
         req.stuf_message.create_elm.assert_called_with('A B C THE PATH')
 
-    def test_validate(self):
-        # Default validation is to return no errors: None
-        req = StufRequestImpl('', '')
-        self.assertIsNone(req.validate({}))
-
     def test_params_errors(self):
         req = StufRequestImpl('', '')
         result = req.params_errors([], [])

--- a/src/tests/stuf/test_message.py
+++ b/src/tests/stuf/test_message.py
@@ -102,7 +102,7 @@ class StufMessageTest(TestCase):
         message.tree = MagicMock()
 
         self.assertEqual(mock_et.tostring(), message.to_string())
-        mock_et.tostring.assert_called_with(message.tree, encoding='unicode')
+        mock_et.tostring.assert_called_with(message.tree, encoding='utf-8')
 
     @patch("gobstuf.stuf.message.ET")
     @patch("gobstuf.stuf.message.minidom.parseString")
@@ -123,7 +123,7 @@ class StufMessageTest(TestCase):
 
         res = message.pretty_print()
         mock_parsestr.assert_called_with(mock_et.tostring.return_value)
-        mock_et.tostring.assert_called_with(message.tree)
+        mock_et.tostring.assert_called_with(message.tree, encoding='utf-8')
         self.assertEqual('A\nB\nC', res)
 
 

--- a/src/tests/stuf/test_message.py
+++ b/src/tests/stuf/test_message.py
@@ -240,6 +240,11 @@ class TestXML(TestCase):
         stuf_message.set_elm_value('elm7', 'elm7value')
         self.assertEqual('elm7value', stuf_message.get_elm_value('elm7'))
 
+        # Try to create element with namespace
+        stuf_message.create_elm('elm9 StUF:elm10')
+        stuf_message.set_elm_value('elm9 StUF:elm10', 'the value')
+        self.assertEqual('the value', stuf_message.get_elm_value('elm9 StUF:elm10'))
+
     def test_find_all_elms(self):
         stuf_message = StufMessage(self.msg)
 


### PR DESCRIPTION
PGB-1241 Add Filtering on geslachtsnaam and geboortedatum to IngeschrevenPersonen endpoint.
Add convert functionality for StUF template for when the query parameter differs from the value expected by MKS.
Introduce a separate call to set_values when creating a request template; first validate the parameters, then set.
Print stacktrace on 500 from view.