### PR TITLE
Add option to search for straat, gemeente en huisnummer

### DIFF
--- a/src/gobstuf/mks_utils.py
+++ b/src/gobstuf/mks_utils.py
@@ -151,12 +151,25 @@ class MKSConverter:
         return as_code
 
     @classmethod
+    def resolve_code(cls, resolver, mks_code):
+        # Make sure we send a 4 digit code to the code resolver
+        as_code = MKSConverter.as_code(4)
+        code = as_code(mks_code)
+        return resolver(code) if code else code
+
+    @classmethod
+    def get_gemeente_code(cls, omschrijving):
+        return CodeResolver.get_gemeente_code(omschrijving)
+
+    @classmethod
     def get_gemeente_omschrijving(cls, mks_code):
-        return CodeResolver.get_gemeente(mks_code)
+        resolver = CodeResolver.get_gemeente
+        return cls.resolve_code(resolver, mks_code)
 
     @classmethod
     def get_land_omschrijving(cls, mks_code):
-        return CodeResolver.get_land(mks_code)
+        resolver = CodeResolver.get_land
+        return cls.resolve_code(resolver, mks_code)
 
     @classmethod
     def true_if_exists(cls, property):

--- a/src/gobstuf/rest/brp/argument_checks.py
+++ b/src/gobstuf/rest/brp/argument_checks.py
@@ -5,6 +5,8 @@ Request argument checks are defined here
 import re
 import datetime
 
+from gobstuf.reference_data.code_resolver import CodeResolver, DataItemNotFoundException
+
 
 def validate_date(value: str):
     try:
@@ -12,6 +14,15 @@ def validate_date(value: str):
     except ValueError:
         return False
 
+    return True
+
+
+def validate_gemeente(value: str):
+    # Try to lookup a valid gemeente code for the supplied value
+    try:
+        CodeResolver.get_gemeente_code(value)
+    except DataItemNotFoundException:
+        return False
     return True
 
 
@@ -62,6 +73,14 @@ class ArgumentCheck():
         'msg': {
             "code": "invalidDate",
             "reason": "Waarde is geen geldige datum",
+        }
+    }
+
+    is_valid_gemeente = {
+        'check': validate_gemeente,
+        'msg': {
+            "code": "invalidGemeente",
+            "reason": "Waarde is geen geldige gemeente",
         }
     }
 

--- a/src/gobstuf/rest/brp/views.py
+++ b/src/gobstuf/rest/brp/views.py
@@ -32,6 +32,9 @@ class IngeschrevenpersonenFilterView(IngeschrevenpersonenView, StufRestFilterVie
     query_parameter_combinations = [
         ['burgerservicenummer'],
         ['verblijfplaats__postcode', 'verblijfplaats__huisnummer'],
+        ['verblijfplaats__gemeentevaninschrijving',
+         'verblijfplaats__naamopenbareruimte',
+         'verblijfplaats__huisnummer'],
         ['geboorte__datum', 'naam__geslachtsnaam'],
     ]
 

--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -2,6 +2,7 @@ import re
 
 from abc import ABC
 
+from gobstuf.reference_data.code_resolver import CodeResolver
 from gobstuf.rest.brp.argument_checks import ArgumentCheck
 from gobstuf.stuf.brp.base_request import StufRequest
 
@@ -24,6 +25,8 @@ class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
         'burgerservicenummer': 'BG:gelijk BG:inp.bsn',
         'verblijfplaats__postcode': 'BG:gelijk BG:verblijfsadres BG:aoa.postcode',
         'verblijfplaats__huisnummer': 'BG:gelijk BG:verblijfsadres BG:aoa.huisnummer',
+        'verblijfplaats__naamopenbareruimte': 'BG:gelijk BG:verblijfsadres BG:gor.openbareRuimteNaam',
+        'verblijfplaats__gemeentevaninschrijving': 'BG:gelijk BG:gem.gemeenteCode',
         'geboorte__datum': 'BG:gelijk BG:geboortedatum',
         'naam__geslachtsnaam': 'BG:gelijk BG:geslachtsnaam',
     }
@@ -32,6 +35,7 @@ class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
         'inclusiefoverledenpersonen': ArgumentCheck.is_boolean,
         'verblijfplaats__postcode': ArgumentCheck.is_postcode,
         'verblijfplaats__huisnummer': [ArgumentCheck.is_integer, ArgumentCheck.is_positive_integer],
+        'verblijfplaats__gemeentevaninschrijving': [ArgumentCheck.is_valid_gemeente],
         'geboorte__datum': [ArgumentCheck.is_valid_date_format, ArgumentCheck.is_valid_date],
         'naam__geslachtsnaam': [ArgumentCheck.has_max_length(200)],
         'burgerservicenummer': IngeschrevenpersonenStufRequest.bsn_check
@@ -46,6 +50,14 @@ class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
         assert date_match.match(value), "This value should already be validated here"
 
         return value.replace('-', '')
+
+    def convert_param_verblijfplaats__gemeentevaninschrijving(self, value: str):
+        """Transforms the supplied gemeente value to a valid gemeentecode
+
+        :param value:
+        :return:
+        """
+        return CodeResolver.get_gemeente_code(value).lstrip('0')
 
 
 class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):

--- a/src/tests/reference_data/test_code_resolver.py
+++ b/src/tests/reference_data/test_code_resolver.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from requests.exceptions import HTTPError, ConnectionError
 
-from gobstuf.reference_data.code_resolver import CodeResolver, CodeNotFoundException
+from gobstuf.reference_data.code_resolver import CodeResolver, DataNotFoundException, DataItemNotFoundException
 
 
 class TestCodeResolver(TestCase):
@@ -15,23 +15,24 @@ class TestCodeResolver(TestCase):
     @patch("builtins.open")
     def test_load_landen(self, mock_open):
         mock_open.side_effect = FileNotFoundError
-        with self.assertRaises(CodeNotFoundException):
-            CodeResolver._load_data(CodeResolver.LANDEN)
-        with self.assertRaises(CodeNotFoundException):
-            CodeResolver._load_data(CodeResolver.GEMEENTEN)
+        with self.assertRaises(DataNotFoundException):
+            CodeResolver._load_data(CodeResolver.LANDEN, CodeResolver.CODE)
+        with self.assertRaises(DataNotFoundException):
+            CodeResolver._load_data(CodeResolver.GEMEENTEN, CodeResolver.CODE)
 
     def test_get_land(self):
         for method_name in ['get_land', 'get_gemeente']:
             method = getattr(CodeResolver, method_name)
 
+            
             result = method("")
             self.assertIsNone(result)
 
             result = method(None)
             self.assertIsNone(result)
 
-            result = method("any code")
-            self.assertIsNone(result)
+            with self.assertRaises(DataItemNotFoundException):
+                result = method("any code")
 
         CodeResolver._landen['any code'] = {'omschrijving': 'any land'}
         result = CodeResolver.get_land("any code")
@@ -42,3 +43,18 @@ class TestCodeResolver(TestCase):
         for code in ['2', '02', '002']:
             CodeResolver.get_land(code)
             self.assertIsNone(CodeResolver._landen.get(code))
+
+    def test_get_gemeente_code(self):
+        method = CodeResolver.get_gemeente_code
+        result = method("")
+        self.assertIsNone(result)
+
+        result = method(None)
+        self.assertIsNone(result)
+
+        with self.assertRaises(DataItemNotFoundException):
+            result = method("any code")
+
+        CodeResolver._gemeenten_omschrijving['any omschrijving'] = {'code': 'any code'}
+        result = CodeResolver.get_gemeente_code("any omschrijving")
+        self.assertEqual(result, 'any code')

--- a/src/tests/rest/brp/test_argument_checks.py
+++ b/src/tests/rest/brp/test_argument_checks.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 from gobstuf.rest.brp.argument_checks import ArgumentCheck
+from gobstuf.reference_data.code_resolver import DataItemNotFoundException
 
 class TestArgumentCheck(TestCase):
 
@@ -56,3 +57,12 @@ class TestArgumentCheck(TestCase):
             self.assertIsNone(ArgumentCheck.validate(check, v))
         for v in [21*'a', 100*'a']:
             self.assertEqual(ArgumentCheck.validate(check, v), check)
+
+    @patch('gobstuf.rest.brp.argument_checks.CodeResolver')
+    def test_validate_gemeente(self, mock_code_resolver):
+        mock_code_resolver.get_gemeente_code.side_effect = ['any code', DataItemNotFoundException()]
+
+        check = ArgumentCheck.is_valid_gemeente
+
+        self.assertIsNone(ArgumentCheck.validate(check, 'any gemeente'))
+        self.assertTrue(ArgumentCheck.validate(check, 'invalid gemeente'))

--- a/src/tests/stuf/brp/request/test_ingeschrevenpersonen.py
+++ b/src/tests/stuf/brp/request/test_ingeschrevenpersonen.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from gobstuf.stuf.brp.request.ingeschrevenpersonen import IngeschrevenpersonenFilterStufRequest
 
@@ -13,3 +14,9 @@ class TestIngeschrevenPersonenFilterStufRequest(TestCase):
         with self.assertRaises(AssertionError):
             request.convert_param_geboorte__datum('INVALID')
 
+    @patch('gobstuf.stuf.brp.request.ingeschrevenpersonen.CodeResolver')
+    def test_convert_param_verblijfplaats__gemeentevaninschrijving(self, mock_code_resolver):
+        mock_code_resolver.get_gemeente_code.return_value = '0363'
+        request = IngeschrevenpersonenFilterStufRequest('gebruiker', 'applicatie')
+
+        self.assertEqual('363', request.convert_param_verblijfplaats__gemeentevaninschrijving('Amsterdam'))

--- a/src/tests/test_mks_utils.py
+++ b/src/tests/test_mks_utils.py
@@ -62,6 +62,11 @@ class TestMKSConverter(TestCase):
         self.assertIsNone(as_code(None))
 
     @patch('gobstuf.mks_utils.CodeResolver')
+    def test_get_gemeente_code(self, mock_code_resolver):
+        mock_code_resolver.get_gemeente_code.return_value = 'any code'
+        self.assertEqual(MKSConverter.get_gemeente_code("any omschrijving"), 'any code')
+
+    @patch('gobstuf.mks_utils.CodeResolver')
     def test_get_gemeente_omschrijving(self, mock_code_resolver):
         mock_code_resolver.get_gemeente.return_value = 'any omschrijving'
         self.assertEqual(MKSConverter.get_gemeente_omschrijving("any gemeente"), 'any omschrijving')


### PR DESCRIPTION
A dictionary was added to be able to search on gemeente by omschrijving instead of code. This resulted in making the code resolver a bit more generic, by not only being able to lookup based on a 4 digit code. The fields were added to the parameter paths with a validation for gemeente.