### PR TITLE
Add links and endpoints for partners

### DIFF
--- a/src/gobstuf/rest/brp/base_view.py
+++ b/src/gobstuf/rest/brp/base_view.py
@@ -193,9 +193,10 @@ class StufRestView(MethodView):
             response_obj = StufErrorResponse(response.text)
             return self._error_response(response_obj)
 
-        # Map MKS response back to REST response.
+        # Map MKS response back to REST response. Include the path parameters to the response
         response_obj = self.response_template(response.text,
-                                              **self._get_functional_query_parameters())
+                                              **self._get_functional_query_parameters(),
+                                              **kwargs)
 
         return self._build_response(response_obj, **kwargs)
 

--- a/src/gobstuf/rest/brp/views.py
+++ b/src/gobstuf/rest/brp/views.py
@@ -1,9 +1,14 @@
 from gobstuf.rest.brp.base_view import StufRestView, StufRestFilterView
 from gobstuf.stuf.brp.request.ingeschrevenpersonen import (
     IngeschrevenpersonenBsnStufRequest,
+    IngeschrevenpersonenBsnPartnerStufRequest,
     IngeschrevenpersonenFilterStufRequest
 )
-from gobstuf.stuf.brp.response.ingeschrevenpersonen import IngeschrevenpersonenStufResponse
+from gobstuf.stuf.brp.response.ingeschrevenpersonen import (
+    IngeschrevenpersonenStufResponse,
+    IngeschrevenpersonenStufPartnersDetailResponse,
+    IngeschrevenpersonenStufPartnersListResponse
+)
 
 
 class IngeschrevenpersonenView(StufRestView):
@@ -52,3 +57,15 @@ class IngeschrevenpersonenBsnView(IngeschrevenpersonenView):
 
     def get_not_found_message(self, **kwargs):
         return f"Ingeschreven persoon niet gevonden met burgerservicenummer {kwargs['bsn']}."
+
+
+class IngeschrevenpersonenBsnPartnerListView(IngeschrevenpersonenBsnView):
+    response_template = IngeschrevenpersonenStufPartnersListResponse
+
+
+class IngeschrevenpersonenBsnPartnerDetailView(IngeschrevenpersonenBsnView):
+    request_template = IngeschrevenpersonenBsnPartnerStufRequest
+    response_template = IngeschrevenpersonenStufPartnersDetailResponse
+
+    def get_not_found_message(self, **kwargs):
+        return f"Ingeschreven partner voor persoon niet gevonden met burgerservicenummer {kwargs['bsn']}."

--- a/src/gobstuf/rest/routes.py
+++ b/src/gobstuf/rest/routes.py
@@ -1,6 +1,15 @@
-from gobstuf.rest.brp.views import IngeschrevenpersonenBsnView, IngeschrevenpersonenFilterView
+from gobstuf.rest.brp.views import (
+    IngeschrevenpersonenBsnView,
+    IngeschrevenpersonenBsnPartnerDetailView,
+    IngeschrevenpersonenBsnPartnerListView,
+    IngeschrevenpersonenFilterView
+)
 
 REST_ROUTES = [
     ('/brp/ingeschrevenpersonen', IngeschrevenpersonenFilterView.as_view('brp_ingeschrevenpersonen_list')),
     ('/brp/ingeschrevenpersonen/<bsn>', IngeschrevenpersonenBsnView.as_view('brp_ingeschrevenpersonen_bsn')),
+    ('/brp/ingeschrevenpersonen/<bsn>/partners',
+     IngeschrevenpersonenBsnPartnerListView.as_view('brp_ingeschrevenpersonen_bsn_partners_list')),
+    ('/brp/ingeschrevenpersonen/<bsn>/partners/<partners_id>',
+     IngeschrevenpersonenBsnPartnerDetailView.as_view('brp_ingeschrevenpersonen_bsn_partners_detail')),
 ]

--- a/src/gobstuf/stuf/brp/base_request.py
+++ b/src/gobstuf/stuf/brp/base_request.py
@@ -26,6 +26,7 @@ class StufRequest(ABC):
     referentienummer_path = 'BG:stuurgegevens StUF:referentienummer'
 
     parameter_checks = {}
+    parameters = []
 
     def __init__(self, gebruiker: str, applicatie: str):
         """
@@ -55,10 +56,13 @@ class StufRequest(ABC):
         :param values:
         :return:
         """
-        assert set(values.keys()) <= set(self.parameter_paths.keys())
+        all_parameters = set([*self.parameter_paths] + self.parameters)
+        assert set(values.keys()) <= all_parameters
 
         for key, value in values.items():
-            self.set_element(self.parameter_paths[key], self._convert_parameter_value(key, value))
+            # Only set the values of parameters which have a path defined
+            if key in self.parameter_paths:
+                self.set_element(self.parameter_paths[key], self._convert_parameter_value(key, value))
 
     def _convert_parameter_value(self, key: str, value: str):
         """Converts parameter value for key before injecting the value in the template.

--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -61,8 +61,6 @@ class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
 
 
 class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):
-    BSN_LENGTH = 9
-
     parameter_paths = {
         'bsn': 'BG:gelijk BG:inp.bsn'
     }
@@ -73,16 +71,5 @@ class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):
     }
 
 
-class IngeschrevenpersonenBsnPartnerStufRequest(IngeschrevenpersonenStufRequest):
-    BSN_LENGTH = 9
-
+class IngeschrevenpersonenBsnPartnerStufRequest(IngeschrevenpersonenBsnStufRequest):
     parameters = ['partners_id']
-
-    parameter_paths = {
-        'bsn': 'BG:gelijk BG:inp.bsn',
-    }
-
-    parameter_checks = {
-        'bsn': IngeschrevenpersonenStufRequest.bsn_check,
-        'inclusiefoverledenpersonen': ArgumentCheck.is_boolean,
-    }

--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -71,3 +71,18 @@ class IngeschrevenpersonenBsnStufRequest(IngeschrevenpersonenStufRequest):
         'bsn': IngeschrevenpersonenStufRequest.bsn_check,
         'inclusiefoverledenpersonen': ArgumentCheck.is_boolean,
     }
+
+
+class IngeschrevenpersonenBsnPartnerStufRequest(IngeschrevenpersonenStufRequest):
+    BSN_LENGTH = 9
+
+    parameters = ['partners_id']
+
+    parameter_paths = {
+        'bsn': 'BG:gelijk BG:inp.bsn',
+    }
+
+    parameter_checks = {
+        'bsn': IngeschrevenpersonenStufRequest.bsn_check,
+        'inclusiefoverledenpersonen': ArgumentCheck.is_boolean,
+    }

--- a/src/gobstuf/stuf/brp/response/filters.py
+++ b/src/gobstuf/stuf/brp/response/filters.py
@@ -1,0 +1,9 @@
+from gobstuf.stuf.brp.base_response import RelatedDetailResponseFilter, RelatedListResponseFilter
+
+
+class PartnersDetailResponseFilter(RelatedDetailResponseFilter):
+    related_type = 'partners'
+
+
+class PartnersListResponseFilter(RelatedListResponseFilter):
+    related_type = 'partners'

--- a/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
@@ -1,4 +1,4 @@
-from gobstuf.stuf.brp.base_response import StufMappedResponse
+from gobstuf.stuf.brp.base_response import RelatedDetailResponse, RelatedListResponse, StufMappedResponse
 
 
 class IngeschrevenpersonenStufResponse(StufMappedResponse):
@@ -7,3 +7,11 @@ class IngeschrevenpersonenStufResponse(StufMappedResponse):
 
     # These properties are passed to the filter method of the mapped object
     filter_kwargs = ['inclusiefoverledenpersonen']
+
+
+class IngeschrevenpersonenStufPartnersDetailResponse(IngeschrevenpersonenStufResponse):
+    response_type = RelatedDetailResponse('partners')
+
+
+class IngeschrevenpersonenStufPartnersListResponse(IngeschrevenpersonenStufResponse):
+    response_type = RelatedListResponse('partners')

--- a/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
@@ -1,4 +1,5 @@
-from gobstuf.stuf.brp.base_response import RelatedDetailResponse, RelatedListResponse, StufMappedResponse
+from gobstuf.stuf.brp.base_response import StufMappedResponse
+from gobstuf.stuf.brp.response.filters import PartnersDetailResponseFilter, PartnersListResponseFilter
 
 
 class IngeschrevenpersonenStufResponse(StufMappedResponse):
@@ -10,8 +11,8 @@ class IngeschrevenpersonenStufResponse(StufMappedResponse):
 
 
 class IngeschrevenpersonenStufPartnersDetailResponse(IngeschrevenpersonenStufResponse):
-    response_type = RelatedDetailResponse('partners')
+    response_filters = [PartnersDetailResponseFilter]
 
 
 class IngeschrevenpersonenStufPartnersListResponse(IngeschrevenpersonenStufResponse):
-    response_type = RelatedListResponse('partners')
+    response_filters = [PartnersListResponseFilter]

--- a/src/gobstuf/stuf/brp/response_mapping.py
+++ b/src/gobstuf/stuf/brp/response_mapping.py
@@ -244,6 +244,24 @@ class NPSMapping(Mapping):
                 'href': flask_url('brp_ingeschrevenpersonen_bsn', bsn=mapped_object['burgerservicenummer'])
             }
 
+        if mapped_object.get('_embedded', {}).get('partners'):
+            # Add the link to all partners
+            links['partners'] = {
+                'href': flask_url('brp_ingeschrevenpersonen_bsn_partners_list',
+                                  bsn=mapped_object['burgerservicenummer'])
+            }
+
+            # Add the links to the partner details
+            for c, partner in enumerate(mapped_object['_embedded']['partners'], 1):
+                partner['_links'] = {
+                    **partner.get('_links', {}),
+                    'self': {
+                        'href': flask_url('brp_ingeschrevenpersonen_bsn_partners_detail',
+                                          bsn=mapped_object['burgerservicenummer'],
+                                          partners_id=c)
+                    }
+                }
+
         return links
 
 

--- a/src/tests/rest/brp/test_base_view.py
+++ b/src/tests/rest/brp/test_base_view.py
@@ -250,7 +250,7 @@ class TestStufRestView(TestCase):
         view.request_template.return_value.set_values.assert_called_with({'a': 1, 'b': 2})
         view._make_request.assert_called_with(view.request_template.return_value)
 
-        view.response_template.assert_called_with(view._make_request.return_value.text, funcparam=True)
+        view.response_template.assert_called_with(view._make_request.return_value.text, a=1, b=2, funcparam=True)
         mock_rest_response.ok.assert_called_with(view.response_template.return_value.get_answer_object.return_value)
 
         # Error response

--- a/src/tests/rest/brp/test_views.py
+++ b/src/tests/rest/brp/test_views.py
@@ -4,9 +4,14 @@ from unittest.mock import patch, MagicMock
 from gobstuf.rest.brp.views import (
     IngeschrevenpersonenView,
     IngeschrevenpersonenBsnView,
+    IngeschrevenpersonenBsnPartnerListView,
+    IngeschrevenpersonenBsnPartnerDetailView,
     IngeschrevenpersonenFilterView,
     IngeschrevenpersonenStufResponse,
-    IngeschrevenpersonenBsnStufRequest
+    IngeschrevenpersonenStufPartnersListResponse,
+    IngeschrevenpersonenStufPartnersDetailResponse,
+    IngeschrevenpersonenBsnStufRequest,
+    IngeschrevenpersonenBsnPartnerStufRequest
 )
 
 
@@ -41,3 +46,23 @@ class TestIngeschrevenpersonenBsnView(TestCase):
         self.assertIn('inclusiefoverledenpersonen', view.functional_query_parameters)
         self.assertTrue(view.functional_query_parameters['inclusiefoverledenpersonen'])
 
+
+class TestIngeschrevenpersonenBsnPartnerListView(TestCase):
+
+    @patch("gobstuf.rest.brp.views.StufRestView", MagicMock())
+    def test_templates_set(self):
+        self.assertEqual(IngeschrevenpersonenStufPartnersListResponse, IngeschrevenpersonenBsnPartnerListView.response_template)
+        self.assertEqual(IngeschrevenpersonenBsnStufRequest, IngeschrevenpersonenBsnPartnerListView.request_template)
+
+
+class TestIngeschrevenpersonenBsnPartnerDetailView(TestCase):
+
+    @patch("gobstuf.rest.brp.views.StufRestView", MagicMock())
+    def test_templates_set(self):
+        self.assertEqual(IngeschrevenpersonenStufPartnersDetailResponse, IngeschrevenpersonenBsnPartnerDetailView.response_template)
+        self.assertEqual(IngeschrevenpersonenBsnPartnerStufRequest, IngeschrevenpersonenBsnPartnerDetailView.request_template)
+
+    def test_get_not_found_message(self):
+        kwargs = {'bsn': 'BEE ES EN'}
+        self.assertEqual('Ingeschreven partner voor persoon niet gevonden met burgerservicenummer BEE ES EN.',
+                         IngeschrevenpersonenBsnPartnerDetailView().get_not_found_message(**kwargs))

--- a/src/tests/stuf/brp/test_response_mapping.py
+++ b/src/tests/stuf/brp/test_response_mapping.py
@@ -122,6 +122,12 @@ class TestNPSMapping(TestCase):
                 }
             },
             'burgerservicenummer': 'digitdigitdigit',
+            '_embedded': {
+                'partners': [
+                    {'burgerservicenummer': 'digitdigitdigit1'},
+                    {'burgerservicenummer': 'digitdigitdigit2'}
+                ]
+            }
         }
 
         self.assertEqual({
@@ -130,8 +136,14 @@ class TestNPSMapping(TestCase):
             },
             'self': {
                 'href': 'http(s)://thishost/brp_ingeschrevenpersonen_bsn/digitdigitdigit'
+            },
+            'partners': {
+                'href': 'http(s)://thishost/brp_ingeschrevenpersonen_bsn_partners_list/digitdigitdigit'
             }
         }, mapping.get_links(mapped_object))
+
+        for c, partner in enumerate(mapped_object['_embedded']['partners']):
+            self.assertEqual(partner['_links']['self']['href'], 'http(s)://thishost/brp_ingeschrevenpersonen_bsn_partners_detail/digitdigitdigit')
 
         mapped_object = {}
         self.assertEqual({}, mapping.get_links(mapped_object))


### PR DESCRIPTION
New routes and views were added for the partner endpoints. The url parameters are now passed to the response template as well, since the partner_id is needed to filter the correct partner from the response object. Related Detail and List reponse types were added to allow for easy filtering on a specific embedded relation (in this case ‘partners’).