### PR TITLE
Change response mapping for nummeraanduiding and adresseerbaarobject

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -19,8 +19,6 @@ COPY deploy /deploy/
 COPY ./keycloak-gatekeeper.latest keycloak-gatekeeper
 COPY ./gatekeeper.conf gatekeeper.conf
 RUN chmod 755 keycloak-gatekeeper
-RUN mkdir -p /var/log/gatekeeper && chown datapunt /var/log/gatekeeper
-
-USER datapunt
+RUN mkdir -p /var/log/gatekeeper
 
 CMD ["/deploy/docker-run.sh"]

--- a/src/gobstuf/stuf/brp/response_mapping.py
+++ b/src/gobstuf/stuf/brp/response_mapping.py
@@ -155,10 +155,10 @@ class NPSMapping(Mapping):
                     'omschrijving': (MKSConverter.get_land_omschrijving, 'BG:inp.immigratieLand')
                 },
                 'woonadres': {
-                    'identificatiecodeNummeraanduiding':
+                    'identificatiecodeNummeraanduiding': 'BG:verblijfsadres BG:aoa.identificatie',
+                    'identificatiecodeAdresseerbaarObject':
                         'BG:inp.verblijftIn BG:gerelateerde StUF:extraElementen' +
-                        '!.//StUF:extraElement[@naam="identificatieNummerAanduiding"]',
-                    'identificatiecodeAdresseerbaarObject': 'BG:verblijfsadres BG:aoa.identificatie',
+                        '!.//StUF:extraElement[@naam="identificatie"]',
                     'naamOpenbareRuimte': 'BG:verblijfsadres BG:gor.openbareRuimteNaam',
                     'huisletter': 'BG:verblijfsadres BG:aoa.huisletter',
                     'huisnummer': 'BG:verblijfsadres BG:aoa.huisnummer',
@@ -171,7 +171,7 @@ class NPSMapping(Mapping):
                         (MKSConverter.as_datum_broken_down, 'BG:verblijfsadres BG:begindatumVerblijf'),
                 },
                 'briefadres': {
-                    'identificatiecodeAdresseerbaarObject': 'BG:sub.correspondentieAdres BG:aoa.identificatie',
+                    'identificatiecodeNummeraanduiding': 'BG:sub.correspondentieAdres BG:aoa.identificatie',
                     'huisletter': 'BG:sub.correspondentieAdres BG:aoa.huisletter',
                     'huisnummer': 'BG:sub.correspondentieAdres BG:aoa.huisnummer',
                     'huisnummertoevoeging': 'BG:sub.correspondentieAdres BG:aoa.huisnummertoevoeging',


### PR DESCRIPTION
It is unclear if identificatiecodeAdresseerbaarObject is returned in the MKS response, it is currently mapped as specced, but the result will be empty for now. The subtask has been flagged.