### PR TITLE
PGB-1598 Run messagebroker thread when app is started in uwsgi mode a…

### DIFF
--- a/src/gobstuf/__main__.py
+++ b/src/gobstuf/__main__.py
@@ -1,55 +1,10 @@
-import datetime
-from threading import Thread
-
-from gobcore.logging.logger import logger
-from gobcore.message_broker.config import WORKFLOW_EXCHANGE, BRP_REGRESSION_TEST_QUEUE, BRP_REGRESSION_TEST_RESULT_KEY
-from gobcore.message_broker.messagedriven_service import messagedriven_service
-
-from gobstuf.api import run as run_api
-from gobstuf.regression_tests.brp import BrpRegression, ObjectstoreResultsWriter
-
-
-def handle_brp_regression_test_msg(msg):
-    logger.configure(msg, 'BRP Regression test')
-
-    results = BrpRegression(logger).run()
-    writer = ObjectstoreResultsWriter(results, 'regression_tests/results/brp')
-    writer.write()
-    logger.info("Written test results to Objecstore at regression_tests/results/brp")
-
-    return {
-        'header': {
-            **msg.get('header', {}),
-            'timestamp': datetime.datetime.utcnow().isoformat(),
-        },
-        'summary': logger.get_summary(),
-    }
-
-
-SERVICEDEFINITION = {
-    'brp_regression_test': {
-        'queue': BRP_REGRESSION_TEST_QUEUE,
-        'handler': handle_brp_regression_test_msg,
-        'report': {
-            'exchange': WORKFLOW_EXCHANGE,
-            'key': BRP_REGRESSION_TEST_RESULT_KEY,
-        }
-    }
-}
-
-
-def run_message_thread():
-    messagedriven_service(SERVICEDEFINITION, "StUF")
+from gobstuf.app import run as run_app
 
 
 def init():
     if __name__ == "__main__":
-        # Start messagedriven_service in separate thread
-        t = Thread(target=run_message_thread)
-        t.start()
-
         # Run the app locally
-        run_api()
+        run_app()
 
 
 init()

--- a/src/gobstuf/api.py
+++ b/src/gobstuf/api.py
@@ -178,7 +178,7 @@ def _add_route(app, paths, rule, view_func, methods, name=None):
         print(wrapped_rule)
 
 
-def get_app():
+def get_flask_app():
     """
     Initializes the Flask App that serves the SOAP endpoint(s)
 
@@ -211,13 +211,3 @@ def get_app():
         _add_route(app, PUBLIC, route, view_func, methods)
 
     return app
-
-
-def run():
-    """
-    Get the Flask app and run it at the port as defined in config
-
-    :return: None
-    """
-    app = get_app()
-    app.run(port=GOB_STUF_PORT)

--- a/src/gobstuf/app.py
+++ b/src/gobstuf/app.py
@@ -1,0 +1,61 @@
+import datetime
+from gobstuf.api import get_flask_app
+from threading import Thread
+
+from gobcore.logging.logger import logger
+from gobcore.message_broker.config import WORKFLOW_EXCHANGE, BRP_REGRESSION_TEST_QUEUE, BRP_REGRESSION_TEST_RESULT_KEY
+from gobcore.message_broker.messagedriven_service import messagedriven_service
+
+from gobstuf.config import GOB_STUF_PORT
+from gobstuf.regression_tests.brp import BrpRegression, ObjectstoreResultsWriter
+
+
+def handle_brp_regression_test_msg(msg):
+    logger.configure(msg, 'BRP Regression test')
+
+    results = BrpRegression(logger).run()
+    writer = ObjectstoreResultsWriter(results, 'regression_tests/results/brp')
+    writer.write()
+    logger.info("Written test results to Objecstore at regression_tests/results/brp")
+
+    return {
+        'header': {
+            **msg.get('header', {}),
+            'timestamp': datetime.datetime.utcnow().isoformat(),
+        },
+        'summary': logger.get_summary(),
+    }
+
+
+SERVICEDEFINITION = {
+    'brp_regression_test': {
+        'queue': BRP_REGRESSION_TEST_QUEUE,
+        'handler': handle_brp_regression_test_msg,
+        'report': {
+            'exchange': WORKFLOW_EXCHANGE,
+            'key': BRP_REGRESSION_TEST_RESULT_KEY,
+        }
+    }
+}
+
+
+def run_message_thread():
+    messagedriven_service(SERVICEDEFINITION, "StUF")
+
+
+def get_app():
+    # Start messagedriven_service in separate thread
+    t = Thread(target=run_message_thread)
+    t.start()
+
+    return get_flask_app()
+
+
+def run():
+    """
+    Get the Flask app and run it at the port as defined in config
+
+    :return: None
+    """
+    app = get_app()
+    app.run(port=GOB_STUF_PORT)

--- a/src/gobstuf/wsgi.py
+++ b/src/gobstuf/wsgi.py
@@ -1,4 +1,4 @@
-from gobstuf.api import get_app
+from gobstuf.app import get_app
 
 # Run the app with uWSGI
 app = get_app()

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from gobstuf.api import _health, _routed_url, _update_response, _update_request
 from gobstuf.api import _get_stuf, _post_stuf, _stuf, _handle_stuf_request
-from gobstuf.api import get_app, run
+from gobstuf.api import get_flask_app
 from werkzeug.exceptions import BadRequest, MethodNotAllowed
 
 class MockResponse:
@@ -154,17 +154,9 @@ class TestAPI(unittest.TestCase):
     def test_get_app(self, mock_flask):
         mock_app = mock.MagicMock()
         mock_flask.return_value = mock_app
-        app = get_app()
+        app = get_flask_app()
         mock_flask.assert_called()
         mock_app.route.assert_called()
-
-    @mock.patch("gobstuf.api.GOB_STUF_PORT", 1234)
-    @mock.patch("gobstuf.api.get_app")
-    def test_run(self, mock_get_app):
-        mock_app = mock.MagicMock()
-        mock_get_app.return_value = mock_app
-        run()
-        mock_app.run.assert_called_with(port=1234)
 
 
 class TestAPIMiddleware(unittest.TestCase):
@@ -175,5 +167,5 @@ class TestAPIMiddleware(unittest.TestCase):
     def test_get_app(self, mock_flask, mock_middleware):
         mock_app = mock.MagicMock()
         mock_flask.return_value = mock_app
-        app = get_app()
+        app = get_flask_app()
         mock_middleware.assert_called_with(app)

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -1,0 +1,54 @@
+import freezegun
+
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from gobstuf.app import handle_brp_regression_test_msg, SERVICEDEFINITION, run_message_thread, run, get_app
+
+
+class TestApp(TestCase):
+
+    @patch("gobstuf.app.ObjectstoreResultsWriter")
+    @patch("gobstuf.app.BrpRegression")
+    @patch("gobstuf.app.logger")
+    def test_handle_brp_regression_test_msg(self, mock_logger, mock_brp_regression, mock_writer):
+        msg = {
+            'header': {
+                'header_attr': 'val',
+            }
+        }
+        with freezegun.freeze_time('2020-08-03 15:30:00'):
+            res = handle_brp_regression_test_msg(msg)
+
+        mock_brp_regression.assert_called_with(mock_logger)
+        mock_writer.assert_called_with(mock_brp_regression().run(), 'regression_tests/results/brp')
+        mock_writer().write.assert_called_once()
+
+        self.assertEqual({
+            'header': {
+                'header_attr': 'val',
+                'timestamp': '2020-08-03T15:30:00',
+            },
+            'summary': mock_logger.get_summary()
+        }, res)
+
+    @patch("gobstuf.app.messagedriven_service")
+    def test_run_message_thread(self, mock_messagedriven_service):
+        run_message_thread()
+        mock_messagedriven_service.assert_called_with(SERVICEDEFINITION, "StUF")
+
+    @patch("gobstuf.app.Thread")
+    @patch("gobstuf.app.get_flask_app")
+    def test_get_app(self, mock_flask_app, mock_thread):
+        self.assertEqual(mock_flask_app(), get_app())
+
+        mock_thread.assert_called_with(target=run_message_thread)
+        mock_thread().start.assert_called_once()
+
+    @patch("gobstuf.app.GOB_STUF_PORT", 1234)
+    @patch("gobstuf.app.get_app")
+    def test_run(self, mock_get_app):
+        mock_app = MagicMock()
+        mock_get_app.return_value = mock_app
+        run()
+        mock_app.run.assert_called_with(port=1234)

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -1,55 +1,13 @@
 import unittest
-import freezegun
-from unittest.mock import MagicMock, call, patch
-
-from gobstuf.__main__ import init, handle_brp_regression_test_msg, run_message_thread, SERVICEDEFINITION
+from unittest.mock import patch
 
 
 class TestMain(unittest.TestCase):
 
-    @patch("gobstuf.__main__.ObjectstoreResultsWriter")
-    @patch("gobstuf.__main__.BrpRegression")
-    @patch("gobstuf.__main__.logger")
-    def test_handle_brp_regression_test_msg(self, mock_logger, mock_brp_regression, mock_writer):
-        msg = {
-            'header': {
-                'header_attr': 'val',
-            }
-        }
-        with freezegun.freeze_time('2020-08-03 15:30:00'):
-            res = handle_brp_regression_test_msg(msg)
-
-        mock_brp_regression.assert_called_with(mock_logger)
-        mock_writer.assert_called_with(mock_brp_regression().run(), 'regression_tests/results/brp')
-        mock_writer().write.assert_called_once()
-
-        self.assertEqual({
-            'header': {
-                'header_attr': 'val',
-                'timestamp': '2020-08-03T15:30:00',
-            },
-            'summary': mock_logger.get_summary()
-        }, res)
-
-    @patch("gobstuf.__main__.messagedriven_service")
-    def test_run_message_thread(self, mock_messagedriven_service):
-        run_message_thread()
-        mock_messagedriven_service.assert_called_with(SERVICEDEFINITION, "StUF")
-
-    @patch("gobstuf.__main__.Thread")
-    @patch("gobstuf.__main__.run_api")
-    def test_init(self, mock_run, mock_thread):
+    @patch("gobstuf.__main__.run_app")
+    def test_init(self, mock_run):
         from gobstuf import __main__ as module
-        m = MagicMock()
-        m.attach_mock(mock_run, 'run')
-        m.attach_mock(mock_thread, 'thread')
 
         with patch.object(module, '__name__', '__main__'):
             module.init()
-
-        m.assert_has_calls([
-            call.thread(target=run_message_thread),
-            call.thread().start(),
-            call.run(),
-        ])
         mock_run.assert_called()

--- a/src/tests/test_wsgi.py
+++ b/src/tests/test_wsgi.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 class TestWsgi(unittest.TestCase):
 
-    @mock.patch('gobstuf.api.get_app')
+    @mock.patch('gobstuf.app.get_app')
     def test_wsgi(self, mock_get_app):
         import gobstuf.wsgi
         mock_get_app.assert_called()


### PR DESCRIPTION
…s well

uwsgi didn't start the message broker thread needed for the BRP regression test listener.

Extracted app-start functionality into its own module, so that there's one entry point to the app, handling starting the message broker as well as Flask.