### PR TITLE
Filter MKS results using regex

### DIFF
--- a/src/gobstuf/rest/brp/argument_checks.py
+++ b/src/gobstuf/rest/brp/argument_checks.py
@@ -6,7 +6,7 @@ import re
 import datetime
 
 from gobstuf.reference_data.code_resolver import CodeResolver, DataItemNotFoundException
-from gobstuf.stuf.message import WILDCARD_CHAR
+from gobstuf.stuf.message import WILDCARD_CHARS
 
 MIN_WILDCARD_LENGTH = 2
 
@@ -31,8 +31,9 @@ def validate_gemeentecode(value: str):
 
 def validate_wildcard_value(value: str):
     # Test is the value is a valid wildcard search when a wildcard is used, meaning it has at least 2 characters
-    if WILDCARD_CHAR in value:
-        return len(re.sub(rf'[\{WILDCARD_CHAR}]', '', value)) >= MIN_WILDCARD_LENGTH
+    if any(wildcard in value for wildcard in WILDCARD_CHARS):
+        wildcard_regex = ''.join(WILDCARD_CHARS)
+        return len(re.sub(rf'[\{wildcard_regex}]', '', value)) >= MIN_WILDCARD_LENGTH
     return True
 
 

--- a/src/gobstuf/stuf/brp/base_request.py
+++ b/src/gobstuf/stuf/brp/base_request.py
@@ -6,7 +6,7 @@ import sys
 
 from abc import ABC, abstractmethod
 
-from gobstuf.stuf.message import StufMessage, WILDCARD_CHAR
+from gobstuf.stuf.message import StufMessage, WILDCARD_CHARS
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'request_template')
 
@@ -67,7 +67,9 @@ class StufRequest(ABC):
                 converted_value = self._convert_parameter_value(key, value)
 
                 # If the field accepts wildcards, check if a wild character is supplied
-                exact_match = False if key in self.parameter_wildcards and WILDCARD_CHAR in converted_value else True
+                exact_match = False if key in self.parameter_wildcards and \
+                    any(wildcard in converted_value for wildcard in WILDCARD_CHARS) \
+                    else True
 
                 self.set_element(self.parameter_paths[key], converted_value, exact_match)
 

--- a/src/gobstuf/stuf/message.py
+++ b/src/gobstuf/stuf/message.py
@@ -1,11 +1,11 @@
 from io import StringIO
-
+import re
 import os
 import xml.etree.ElementTree as ET
 
 from xml.dom import minidom
 
-WILDCARD_CHAR = '*'
+WILDCARD_CHARS = ['*', '?']
 STUF_WILDCARD_CHAR = '%'
 
 
@@ -92,8 +92,8 @@ class StufMessage:
         if not exact_match:
             # Add exact false for wildcard fields
             elm.set('StUF:exact', 'false')
-            value = value.replace(WILDCARD_CHAR, STUF_WILDCARD_CHAR)
-
+            regex = r'[' + re.escape(''.join(WILDCARD_CHARS)) + ']'
+            value = re.sub(regex, STUF_WILDCARD_CHAR, value)
         elm.text = value
 
     def create_elm(self, elements_str: str, tree=None):


### PR DESCRIPTION
The filtering possible in MKS returns more results than expected. A wildcard filter has been added to filter the response objects to match the query