### PR TITLE
Only add the wildcard filter if a wildcard char is provided

### DIFF
--- a/src/gobstuf/rest/brp/base_view.py
+++ b/src/gobstuf/rest/brp/base_view.py
@@ -178,8 +178,9 @@ class StufRestView(MethodView):
                 for k, v in self.functional_query_parameters.items()}
 
     def _get_wildcard_query_parameters(self):
-        wildcards = {wildcard: request.args.get(wildcard) for wildcard in self.request_template.parameter_wildcards
-                     if wildcard in request.args}
+        wildcards = {wildcard_mapping: request.args.get(wildcard_arg)
+                     for wildcard_arg, wildcard_mapping in self.request_template.parameter_wildcards.items()
+                     if wildcard_arg in request.args}
         return {'wildcards': wildcards}
 
     def _get(self, **kwargs):

--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -52,7 +52,12 @@ class IngeschrevenpersonenFilterStufRequest(IngeschrevenpersonenStufRequest):
         'burgerservicenummer': IngeschrevenpersonenStufRequest.bsn_check
     }
 
-    parameter_wildcards = ['naam__voornamen', 'naam__geslachtsnaam', 'verblijfplaats__naamopenbareruimte']
+    # Wildcards are defined by their url parameter and the key in the response object
+    parameter_wildcards = {
+        'naam__voornamen': 'naam__voornamen',
+        'naam__geslachtsnaam': 'naam__geslachtsnaam',
+        'verblijfplaats__naamopenbareruimte': 'verblijfplaats__naamOpenbareRuimte'
+    }
 
     def convert_param_geboorte__datum(self, value: str):
         """Transforms the YYYY-MM-DD value to YYYYMMDD

--- a/src/tests/stuf/brp/test_base_response.py
+++ b/src/tests/stuf/brp/test_base_response.py
@@ -143,8 +143,12 @@ class StufMappedResponseTest(TestCase):
         resp = StufMappedResponseRelatedImpl('msg', expand=None)
         self.assertEqual(1, len(resp.response_filters_instances))
 
-        # When a wildcard is defined, expect the wildcard filter to be initialized
+        # When a wildcard is without wildcard char is defined, except no wildcard filters
         resp = StufMappedResponseImpl('msg', wildcards={'wildcard': 'any wildcard'})
+        self.assertEqual(0, len(resp.response_filters_instances))
+
+        # When a wildcard is defined, expect the wildcard filter to be initialized
+        resp = StufMappedResponseImpl('msg', wildcards={'wildcard': '*any wildcard'})
         self.assertEqual(1, len(resp.response_filters_instances))
 
     def test_get_object_elm(self):


### PR DESCRIPTION
We needed an additional mapping to map url arguments to the response object