### PR TITLE
Remove SECURE_SALT, it is not required

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
       - "8165:8001"
     container_name: gobstuf
     environment:
-      SECURE_SALT: insecure
-      SECURE_PASSWORD: insecure
       MESSAGE_BROKER_ADDRESS: rabbitmq
       UWSGI_HTTP: ":8001"
       UWSGI_MODULE: "gobstuf.wsgi"

--- a/src/test.sh
+++ b/src/test.sh
@@ -13,4 +13,4 @@ echo "Running unit tests"
 pytest tests/
 
 echo "Running coverage tests"
-pytest --cov=gobstuf --cov-report html --cov-fail-under=100
+pytest --cov=gobstuf --cov-report html --cov-fail-under=100 tests/


### PR DESCRIPTION
SECURE_SALT is not required, it is defined in docker however. Remove it, so that we do not need to configure it in OpenStack.