### PR TITLE
Add all rest routes on base path (#279)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,11 +28,13 @@ node() {
 
         stage('Test') {
             tryStep "test", {
-                sh "docker-compose -p gob_stuf_service -f src/.jenkins/test/docker-compose.yml build --no-cache && " +
-                   "docker-compose -p gob_stuf_service -f src/.jenkins/test/docker-compose.yml run -u root --rm test"
+                sh "docker-compose -p gob_stuf_service_${env.BRANCH_NAME} -f src/.jenkins/test/docker-compose.yml up --detach --force-recreate rabbitmq"
+                sh "docker-compose -p gob_stuf_service_${env.BRANCH_NAME} -f src/.jenkins/test/docker-compose.yml build --no-cache && " +
+                   "docker-compose -p gob_stuf_service_${env.BRANCH_NAME} -f src/.jenkins/test/docker-compose.yml run -u root --rm test"
+                sh "docker-compose -p gob_stuf_service_${env.BRANCH_NAME} -f src/.jenkins/test/docker-compose.yml down"
 
             }, {
-                sh "docker-compose -p gob_stuf_service -f src/.jenkins/test/docker-compose.yml down"
+                sh "docker-compose -p gob_stuf_service_${env.BRANCH_NAME} -f src/.jenkins/test/docker-compose.yml down"
             }
         }
 

--- a/src/.jenkins/test/docker-compose.yml
+++ b/src/.jenkins/test/docker-compose.yml
@@ -7,5 +7,14 @@ services:
       target: test
     environment:
       GOB_SHARED_DIR: /app/shared
+      MESSAGE_BROKER_ADDRESS: rabbitmq
     command: >
       bash -c "./test.sh"
+    depends_on:
+      - rabbitmq
+  rabbitmq:
+    image: "rabbitmq:3.9-management"
+    environment:
+      RABBITMQ_CONFIG_FILE: /etc/rabbitmq/rabbitmq.conf
+    volumes:
+      - "./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf"

--- a/src/gobstuf/api.py
+++ b/src/gobstuf/api.py
@@ -1,20 +1,9 @@
-import re
-
-import flask
-from flask import Flask, Response
+from flask import Flask
+from flask_audit_log.middleware import AuditLogMiddleware
 from flask_cors import CORS
 
-from urllib.parse import urlsplit, urlunsplit, SplitResult
-
-from flask_audit_log.middleware import AuditLogMiddleware
-
-from gobstuf.auth.routes import secure_route
-from gobstuf.config import GOB_STUF_PORT, ROUTE_SCHEME, ROUTE_NETLOC, ROUTE_PATH_310, ROUTE_PATH_204, \
-                           API_BASE_PATH, AUDIT_LOG_CONFIG
+from gobstuf.config import AUDIT_LOG_CONFIG
 from gobstuf.logger import get_default_logger
-from gobstuf.certrequest import cert_get, cert_post
-from gobstuf.rest.routes import REST_ROUTES
-from werkzeug.exceptions import BadRequest, MethodNotAllowed, HTTPException
 
 logger = get_default_logger()
 
@@ -25,150 +14,6 @@ def _health():
     :return: Message telling the StUF API is OK
     """
     return 'Connectivity OK'
-
-
-def _routed_url(url):
-    """
-    Transforms an url so that it directs to the underlying SOAP API endpoint
-
-    :param url: url to transform, normally url of our own endpoint
-    :return: the transformed url that points to the underlying SOAP API
-    """
-    split_result = urlsplit(url)
-
-    split_result = SplitResult(
-        scheme=ROUTE_SCHEME,
-        netloc=ROUTE_NETLOC,
-        path=split_result.path.lstrip(API_BASE_PATH),
-        query=split_result.query,
-        fragment=split_result.fragment
-    )
-    routed_url = urlunsplit(split_result)
-
-    # The root wsdl should be requested as a parameter to the url path
-    routed_url = routed_url.replace(r"/?wsdl", r"?wsdl")
-    return routed_url
-
-
-def _update_response(text):
-    """
-    Update any response from the underlying SOAP API so that
-    the address of the underlying api (domain + optional port number) is changed to the address
-    of this StUF API
-
-    :param text: any text, normally a XML string
-    :return: the text where any reference to the underlying SOAP API is changed to ourself
-    """
-    pattern = ROUTE_NETLOC + r"(:\d{2,5})?"
-    return re.sub(pattern, f"localhost:{GOB_STUF_PORT}", text)
-
-
-def _update_request(text):
-    """
-    Update any request data for the underlying SOAP API so that
-    the address of this StUF API is changed to the address of the underlying api (domain + optional port number)
-
-    :param text: any text, normally a XML string
-    :return: the text where any reference to ourself is changed to the underlying SOAP API
-    """
-    pattern = f"localhost:{GOB_STUF_PORT}"
-    return re.sub(pattern, ROUTE_NETLOC, text)
-
-
-def _get_stuf(url):
-    """
-    Get the StUF response from the given url
-
-    :param url: url of SOAP endpoint of underlying SOAP server
-    :return: response object
-    """
-    return cert_get(url)
-
-
-def _post_stuf(url, data, headers):
-    """
-    Post the data to the given url
-
-    :param url: url of SOAP endpoint of underlying SOAP server
-    :param data: XML message contents
-    :param headers: incoming request headers
-    :return: response object
-    """
-    soap_action = headers.get("Soapaction")
-    content_type = headers.get("Content-Type", "")
-
-    if soap_action is None:
-        raise BadRequest("Missing Soapaction in header")
-
-    if "text/xml" not in content_type:
-        raise BadRequest(f"Wrong content {content_type}; text/xml expected")
-
-    headers = {
-        "Soapaction": soap_action,
-        "Content-Type": content_type
-    }
-    return cert_post(url, data=data, headers=headers)
-
-
-def _handle_stuf_request(request, routed_url):
-    method = request.method
-    if method == 'GET':
-        response = _get_stuf(routed_url)
-    elif method == 'POST':
-        data = _update_request(request.data.decode())
-        response = _post_stuf(routed_url, data, request.headers)
-    else:
-        raise MethodNotAllowed(f"Unknown method {method}, GET or POST required")
-
-    return response
-
-
-def _stuf():
-    """
-    Handle StUF request
-
-    :return: XML response
-    """
-    request = flask.request
-    url = _routed_url(request.url)
-
-    request_log_data = {
-        'soapaction': request.headers.get('Soapaction'),
-        'original_url': request.url,
-        'method': request.method,
-    }
-
-    response_log_data = {**request_log_data}
-
-    try:
-        response = _handle_stuf_request(request, url)
-    except HTTPException as e:
-        # If Exception occurs, log exception and re-raise
-        response_log_data['exception'] = str(e)
-        raise e
-
-    # Successful
-    response_log_data['remote_response_code'] = response.status_code
-    text = _update_response(response.text)
-
-    return Response(text, mimetype="text/xml")
-
-
-def _add_route(app, path, rule, view_func, methods, name=None):
-    """
-    For every rule add a secured endpoint. This endpoint expects the keycloak headers to be present and the endpoint is
-    protected by gatekeeper
-
-    :param app:
-    :param rule:
-    :param view_func:
-    :param methods:
-    :return:
-    """
-    wrapped_rule = f"{path}{rule}"
-    app.add_url_rule(rule=wrapped_rule, methods=methods, view_func=secure_route(wrapped_rule, view_func, name=name))
-    # Output the urls on startup
-    logger.info(wrapped_rule)
 
 
 def get_flask_app():
@@ -189,16 +34,10 @@ def get_flask_app():
     # Health check route
     app.route(rule='/status/health/')(_health)
 
-    # Application routes
-    ROUTES = [
-        (API_BASE_PATH, ROUTE_PATH_310, _stuf, ['GET', 'POST'], '310'),
-        (API_BASE_PATH, ROUTE_PATH_204, _stuf, ['GET', 'POST'], '204'),
-    ]
+    # import blueprints, prints endpoints
+    from gobstuf.blueprints import hc_bp, secure_bp
 
-    for path, rule, view_func, methods, name in ROUTES:
-        _add_route(app, path, rule, view_func, methods, name=name)
-
-    for route, view_func in REST_ROUTES:
-        _add_route(app, API_BASE_PATH, route, view_func, ['GET'])
+    app.register_blueprint(secure_bp)
+    app.register_blueprint(hc_bp)
 
     return app

--- a/src/gobstuf/auth/routes.py
+++ b/src/gobstuf/auth/routes.py
@@ -4,7 +4,6 @@ from flask import g, request, url_for
 
 from gobcore.secure.request import is_secured_request, extract_roles, USER_NAME_HEADER
 
-
 REQUIRED_ROLE_PREFIX = 'fp_'
 REQUIRED_ROLE = 'brp_r'
 
@@ -12,15 +11,14 @@ MKS_USER_KEY = 'MKS_GEBRUIKER'
 MKS_APPLICATION_KEY = 'MKS_APPLICATIE'
 
 
-def secure_route(rule: str, func: Callable, name: str = None) -> Callable:
+def secure_route(rule: str, func: Callable) -> Callable:
     """
     Secure routes are protected by oauth2-proxy.
     The headers that are used to identify the user and/or role should be present.
 
     :param rule: route/rule to secure
     :param func: view function
-    :param name: (optional) route name
-    :return: 403 if access is not allowed, else `func`
+    :return: 403 if access is not allowed, else wrapped `func`
     """
     def wrapper(*args, **kwargs) -> tuple[str, int]:
         # Check that the endpoint is protected by oauth2-proxy and check access
@@ -29,7 +27,7 @@ def secure_route(rule: str, func: Callable, name: str = None) -> Callable:
         else:
             return "Forbidden", 403
 
-    wrapper.__name__ = func.__name__ if name is None else name
+    wrapper.__name__ = func.__name__
     return wrapper
 
 
@@ -55,5 +53,5 @@ def _allows_access(rule, *args, **kwargs) -> bool:
 
 
 def get_auth_url(view_name, **kwargs):
-    url = url_for(view_name, **kwargs)
-    return f"{request.scheme}://{request.host}{url}"
+    view_url = url_for(f"{request.blueprint}.{view_name}", **kwargs)
+    return f"{request.scheme}://{request.host}{view_url}"

--- a/src/gobstuf/blueprints/__init__.py
+++ b/src/gobstuf/blueprints/__init__.py
@@ -1,0 +1,2 @@
+from gobstuf.blueprints.hc import hc_bp  # noqa: F401
+from gobstuf.blueprints.secure import secure_bp  # noqa: F401

--- a/src/gobstuf/blueprints/hc.py
+++ b/src/gobstuf/blueprints/hc.py
@@ -1,0 +1,15 @@
+from flask import Blueprint
+
+from gobstuf.auth.routes import secure_route
+from gobstuf.config import HC_BASE_PATH
+from gobstuf.logger import get_default_logger
+from gobstuf.rest.routes import REST_ROUTES
+
+logger = get_default_logger()
+
+hc_bp = Blueprint('hc', __name__, url_prefix=HC_BASE_PATH)
+
+
+for rule, view_func, methods in REST_ROUTES:
+    hc_bp.add_url_rule(rule=rule, methods=methods, view_func=secure_route(rule, view_func))
+    logger.info(hc_bp.url_prefix + rule)

--- a/src/gobstuf/blueprints/secure.py
+++ b/src/gobstuf/blueprints/secure.py
@@ -1,0 +1,167 @@
+import re
+from urllib.parse import urlsplit, SplitResult, urlunsplit
+
+import flask
+from flask import Blueprint, Response
+from werkzeug.exceptions import BadRequest, MethodNotAllowed, HTTPException
+
+from gobstuf.auth.routes import secure_route
+from gobstuf.certrequest import cert_get, cert_post
+from gobstuf.config import API_BASE_PATH, ROUTE_PATH_310, ROUTE_PATH_204, ROUTE_SCHEME, ROUTE_NETLOC, GOB_STUF_PORT
+from gobstuf.logger import get_default_logger
+from gobstuf.rest.routes import REST_ROUTES
+
+logger = get_default_logger()
+
+
+def _routed_url(url):
+    """
+    Transforms an url so that it directs to the underlying SOAP API endpoint
+
+    :param url: url to transform, normally url of our own endpoint
+    :return: the transformed url that points to the underlying SOAP API
+    """
+    split_result = urlsplit(url)
+
+    split_result = SplitResult(
+        scheme=ROUTE_SCHEME,
+        netloc=ROUTE_NETLOC,
+        path=split_result.path.lstrip(API_BASE_PATH),
+        query=split_result.query,
+        fragment=split_result.fragment
+    )
+    routed_url = urlunsplit(split_result)
+
+    # The root wsdl should be requested as a parameter to the url path
+    routed_url = routed_url.replace(r"/?wsdl", r"?wsdl")
+    return routed_url
+
+
+def _update_response(text):
+    """
+    Update any response from the underlying SOAP API so that
+    the address of the underlying api (domain + optional port number) is changed to the address
+    of this StUF API
+
+    :param text: any text, normally a XML string
+    :return: the text where any reference to the underlying SOAP API is changed to ourself
+    """
+    pattern = ROUTE_NETLOC + r"(:\d{2,5})?"
+    return re.sub(pattern, f"localhost:{GOB_STUF_PORT}", text)
+
+
+def _update_request(text):
+    """
+    Update any request data for the underlying SOAP API so that
+    the address of this StUF API is changed to the address of the underlying api (domain + optional port number)
+
+    :param text: any text, normally a XML string
+    :return: the text where any reference to ourself is changed to the underlying SOAP API
+    """
+    pattern = f"localhost:{GOB_STUF_PORT}"
+    return re.sub(pattern, ROUTE_NETLOC, text)
+
+
+def _get_stuf(url):
+    """
+    Get the StUF response from the given url
+
+    :param url: url of SOAP endpoint of underlying SOAP server
+    :return: response object
+    """
+    return cert_get(url)
+
+
+def _post_stuf(url, data, headers):
+    """
+    Post the data to the given url
+
+    :param url: url of SOAP endpoint of underlying SOAP server
+    :param data: XML message contents
+    :param headers: incoming request headers
+    :return: response object
+    """
+    soap_action = headers.get("Soapaction")
+    content_type = headers.get("Content-Type", "")
+
+    if soap_action is None:
+        raise BadRequest("Missing Soapaction in header")
+
+    if "text/xml" not in content_type:
+        raise BadRequest(f"Wrong content {content_type}; text/xml expected")
+
+    headers = {
+        "Soapaction": soap_action,
+        "Content-Type": content_type
+    }
+    return cert_post(url, data=data, headers=headers)
+
+
+def _handle_stuf_request(request, routed_url):
+    method = request.method
+    if method == 'GET':
+        response = _get_stuf(routed_url)
+    elif method == 'POST':
+        data = _update_request(request.data.decode())
+        response = _post_stuf(routed_url, data, request.headers)
+    else:
+        raise MethodNotAllowed(f"Unknown method {method}, GET or POST required")
+
+    return response
+
+
+def _stuf():
+    """Forward stuf request to mks server, return response as recieved.
+    :return: XML response
+    """
+    request = flask.request
+    url = _routed_url(request.url)
+
+    request_log_data = {
+        'soapaction': request.headers.get('Soapaction'),
+        'original_url': request.url,
+        'method': request.method,
+    }
+
+    response_log_data = {**request_log_data}
+
+    try:
+        response = _handle_stuf_request(request, url)
+    except HTTPException as e:
+        # If Exception occurs, log exception and re-raise
+        response_log_data['exception'] = str(e)
+        raise e
+
+    # Successful
+    response_log_data['remote_response_code'] = response.status_code
+    text = _update_response(response.text)
+
+    return Response(text, mimetype="text/xml")
+
+
+secure_bp = Blueprint('secure', __name__, url_prefix=API_BASE_PATH)
+
+
+XML_ROUTES = [
+    (ROUTE_PATH_310, _stuf, ['GET', 'POST'], "stuf_310"),
+    (ROUTE_PATH_204, _stuf, ['GET', 'POST'], "stuf_204")
+]
+
+
+for rule, view_func, methods in REST_ROUTES:
+    secure_bp.add_url_rule(
+        rule=rule,
+        methods=methods,
+        view_func=secure_route(rule, view_func)
+    )
+    logger.info(secure_bp.url_prefix + rule)
+
+
+for rule, view_func, methods, endpoint in XML_ROUTES:
+    secure_bp.add_url_rule(
+        rule=rule,
+        methods=methods,
+        view_func=secure_route(rule, view_func),
+        endpoint=endpoint
+    )
+    logger.info(secure_bp.url_prefix + rule)

--- a/src/gobstuf/config.py
+++ b/src/gobstuf/config.py
@@ -29,7 +29,10 @@ ROUTE_SCHEME = _getenv("ROUTE_SCHEME", default_value="https")
 PKCS12_FILENAME = _getenv("PKCS12_FILENAME", is_optional=True)
 PKCS12_PASSWORD = _getenv("PKCS12_PASSWORD", is_optional=True)
 
-API_BASE_PATH = _getenv("BASE_PATH", default_value="", is_optional=True)
+API_BASE_PATH = _getenv("API_BASE_PATH", default_value="", is_optional=True)
+HC_BASE_PATH = _getenv("HC_BASE_PATH", default_value="", is_optional=True)
+
+BASE_PATHS = [API_BASE_PATH, HC_BASE_PATH]
 
 AUDIT_LOG_CONFIG = {
     'EXEMPT_URLS': [],

--- a/src/gobstuf/rest/routes.py
+++ b/src/gobstuf/rest/routes.py
@@ -10,18 +10,44 @@ from gobstuf.rest.brp.views import (
 )
 
 REST_ROUTES = [
-    ('/brp/ingeschrevenpersonen', IngeschrevenpersonenFilterView.as_view('brp_ingeschrevenpersonen_list')),
-    ('/brp/ingeschrevenpersonen/<bsn>', IngeschrevenpersonenBsnView.as_view('brp_ingeschrevenpersonen_bsn')),
-    ('/brp/ingeschrevenpersonen/<bsn>/partners',
-     IngeschrevenpersonenBsnPartnerListView.as_view('brp_ingeschrevenpersonen_bsn_partners_list')),
-    ('/brp/ingeschrevenpersonen/<bsn>/partners/<partners_id>',
-     IngeschrevenpersonenBsnPartnerDetailView.as_view('brp_ingeschrevenpersonen_bsn_partners_detail')),
-    ('/brp/ingeschrevenpersonen/<bsn>/ouders',
-     IngeschrevenpersonenBsnOudersListView.as_view('brp_ingeschrevenpersonen_bsn_ouders_list')),
-    ('/brp/ingeschrevenpersonen/<bsn>/ouders/<ouders_id>',
-     IngeschrevenpersonenBsnOudersDetailView.as_view('brp_ingeschrevenpersonen_bsn_ouders_detail')),
-    ('/brp/ingeschrevenpersonen/<bsn>/kinderen',
-     IngeschrevenpersonenBsnKinderenListView.as_view('brp_ingeschrevenpersonen_bsn_kinderen_list')),
-    ('/brp/ingeschrevenpersonen/<bsn>/kinderen/<kinderen_id>',
-     IngeschrevenpersonenBsnKinderenDetailView.as_view('brp_ingeschrevenpersonen_bsn_kinderen_detail')),
+    (
+        '/brp/ingeschrevenpersonen',
+        IngeschrevenpersonenFilterView.as_view('brp_ingeschrevenpersonen_list'),
+        ["GET"]
+    ),
+    (
+        '/brp/ingeschrevenpersonen/<bsn>',
+        IngeschrevenpersonenBsnView.as_view('brp_ingeschrevenpersonen_bsn'),
+        ["GET"]
+    ),
+    (
+        '/brp/ingeschrevenpersonen/<bsn>/partners',
+        IngeschrevenpersonenBsnPartnerListView.as_view('brp_ingeschrevenpersonen_bsn_partners_list'),
+        ["GET"]
+    ),
+    (
+        '/brp/ingeschrevenpersonen/<bsn>/partners/<partners_id>',
+        IngeschrevenpersonenBsnPartnerDetailView.as_view('brp_ingeschrevenpersonen_bsn_partners_detail'),
+        ["GET"]
+    ),
+    (
+        '/brp/ingeschrevenpersonen/<bsn>/ouders',
+        IngeschrevenpersonenBsnOudersListView.as_view('brp_ingeschrevenpersonen_bsn_ouders_list'),
+        ["GET"]
+    ),
+    (
+        '/brp/ingeschrevenpersonen/<bsn>/ouders/<ouders_id>',
+        IngeschrevenpersonenBsnOudersDetailView.as_view('brp_ingeschrevenpersonen_bsn_ouders_detail'),
+        ["GET"]
+    ),
+    (
+        '/brp/ingeschrevenpersonen/<bsn>/kinderen',
+        IngeschrevenpersonenBsnKinderenListView.as_view('brp_ingeschrevenpersonen_bsn_kinderen_list'),
+        ["GET"]
+    ),
+    (
+        '/brp/ingeschrevenpersonen/<bsn>/kinderen/<kinderen_id>',
+        IngeschrevenpersonenBsnKinderenDetailView.as_view('brp_ingeschrevenpersonen_bsn_kinderen_detail'),
+        ["GET"]
+    ),
 ]

--- a/src/tests/pytest.ini
+++ b/src/tests/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
 addopts = --capture=no
 env =
-    BASE_PATH=/gob_stuf_test
+    API_BASE_PATH=/gob_stuf_test
+    HC_BASE_PATH=
     ROUTE_PATH_310=/310
     ROUTE_PATH_204=/204
     ROUTE_SCHEME=http

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -1,11 +1,13 @@
 import unittest
-from unittest import mock
 from os import environ
+from unittest import mock
 
-from gobstuf.api import _health, _routed_url, _update_response, _update_request
-from gobstuf.api import _get_stuf, _post_stuf, _stuf, _handle_stuf_request
-from gobstuf.api import get_flask_app
 from werkzeug.exceptions import BadRequest, MethodNotAllowed
+
+from gobstuf.api import _health
+from gobstuf.api import get_flask_app
+from gobstuf.blueprints.secure import _routed_url, _update_response, _update_request, _get_stuf, _post_stuf, _stuf, \
+    _handle_stuf_request
 
 
 class MockResponse:
@@ -69,7 +71,7 @@ class TestAPI(unittest.TestCase):
         result = _update_request("...localhost...")
         self.assertEqual(result, "...localhost...")
 
-    @mock.patch("gobstuf.api.cert_get")
+    @mock.patch("gobstuf.blueprints.secure.cert_get")
     def test_get_stuf(self, mock_get):
         mock_get.return_value = "get"
 
@@ -77,7 +79,7 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(response, "get")
         mock_get.assert_called_with("any url")
 
-    @mock.patch("gobstuf.api.cert_post")
+    @mock.patch("gobstuf.blueprints.secure.cert_post")
     def test_post_stuf(self, mock_post):
         mock_post.return_value = "post"
 
@@ -105,9 +107,9 @@ class TestAPI(unittest.TestCase):
                 headers = h
                 response = _post_stuf(url, data, headers)
 
-    @mock.patch("gobstuf.api._get_stuf")
-    @mock.patch("gobstuf.api._post_stuf")
-    @mock.patch("gobstuf.api._update_request")
+    @mock.patch("gobstuf.blueprints.secure._get_stuf")
+    @mock.patch("gobstuf.blueprints.secure._post_stuf")
+    @mock.patch("gobstuf.blueprints.secure._update_request")
     def test_handle_stuf_request(self, mock_update_request, mock_post_stuf, mock_get_stuf):
         routed_url = 'routed url'
 
@@ -123,8 +125,8 @@ class TestAPI(unittest.TestCase):
         with self.assertRaisesRegex(MethodNotAllowed, '405 Method Not Allowed'):
             _handle_stuf_request(request, routed_url)
 
-    @mock.patch("gobstuf.api._handle_stuf_request", return_value=MockResponse('get', 123))
-    @mock.patch("gobstuf.api.flask")
+    @mock.patch("gobstuf.blueprints.secure._handle_stuf_request", return_value=MockResponse('get', 123))
+    @mock.patch("gobstuf.blueprints.secure.flask")
     def test_stuf(self, mock_flask, mock_handle_stuf):
         mock_flask.request.method = 'GET'
         mock_flask.request.url = "any url"
@@ -137,8 +139,8 @@ class TestAPI(unittest.TestCase):
         response = _stuf()
         self.assertEqual(response.data, b"get")
 
-    @mock.patch("gobstuf.api._handle_stuf_request", return_value=MockResponse('get', 123))
-    @mock.patch("gobstuf.api.flask")
+    @mock.patch("gobstuf.blueprints.secure._handle_stuf_request", return_value=MockResponse('get', 123))
+    @mock.patch("gobstuf.blueprints.secure.flask")
     def test_stuf_exception(self, mock_flask, mock_handle_stuf):
         mock_handle_stuf.side_effect = BadRequest("Exception message")
 


### PR DESCRIPTION
Used to give HC its own endpoint.

* Add new route using blueprints
* Make rabbitmq tests work
* Give _stuf function its own endpoint name
* Make tests initialize rabbitmq

Co-authored-by: Roel Kramer <contact@roelkramer.nl>