### PR TITLE
Return correct error message when bsn is not valid

### DIFF
--- a/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/request/ingeschrevenpersonen.py
@@ -13,9 +13,9 @@ class IngeschrevenpersonenStufRequest(StufRequest, ABC):
     BSN_LENGTH = 9
 
     bsn_check = [
-        ArgumentCheck.is_integer,
         ArgumentCheck.has_min_length(BSN_LENGTH),
         ArgumentCheck.has_max_length(BSN_LENGTH),
+        ArgumentCheck.is_integer
     ]
 
     template = 'ingeschrevenpersonen.xml'


### PR DESCRIPTION
see: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/issues/499

First check the length, if not valid raise this error. If valid check for digits.