### PR TITLE
Fix writing objectstore objects

### DIFF
--- a/src/gobstuf/regression_tests/brp.py
+++ b/src/gobstuf/regression_tests/brp.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import os
 import shutil
-from typing import List, Callable, Any
+from typing import List, Callable, Any, Iterator
 
 import requests
 from requests import HTTPError
@@ -60,7 +60,7 @@ class Objectstore:
     def _get_objects_list(self):
         return get_full_container_list(self.connection, CONTAINER_BASE)
 
-    def _get_object(self, item):
+    def _get_object(self, item) -> Iterator[bytes]:
         return get_object(self.connection, item, CONTAINER_BASE)
 
     def _delete_object(self, item):
@@ -86,7 +86,8 @@ class Objectstore:
                     dst_directory = '/'.join(save_path.split('/')[:-1])
                     os.makedirs(dst_directory, exist_ok=True)
                     with open(save_path, 'wb') as f:
-                        f.write(obj)
+                        for chunk in obj:
+                            f.write(chunk)
 
     def clear_directory(self, objectstore_path: str):
         for item in self._get_objects_list():

--- a/src/tests/regression_tests/test_brp.py
+++ b/src/tests/regression_tests/test_brp.py
@@ -105,7 +105,7 @@ class TestObjectStore(TestCase):
             {'name': 'dira/dird/filed.json', 'content_type': 'application/json'},
             {'name': 'dira/dirb/dirf/somefile.json', 'content_type': 'application/json'},
         ])
-        store._get_object = lambda x: 'downloaded(' + x['name'] + ')'
+        store._get_object = lambda x: [f'downloaded({x["name"]})']
 
         store.download_directory('dira/dirb', 'local/directory')
 


### PR DESCRIPTION
get_object returns iterator instead of bytes

https://github.com/Amsterdam/GOB-Core/commit/d6bc469da5595d83b7361ec52d441fb1cce1f0ab