### PR TITLE
Let response mapping depend on the answer code

### DIFF
--- a/src/gobstuf/stuf/brp/base_response.py
+++ b/src/gobstuf/stuf/brp/base_response.py
@@ -266,7 +266,7 @@ class StufMappedResponse(StufResponse):
         :return:
         """
         stuf_entity_type = element.attrib.get('{%s}entiteittype' % self.namespaces['StUF'])
-        return StufObjectMapping.get_for_entity_type(stuf_entity_type)
+        return StufObjectMapping.get_for_entity_type(self.answer_code, stuf_entity_type)
 
     def _get_mapped_related_object(self, mapping: RelatedMapping, wrapper_element: Element):
         """Returns the mapping for the inner entity of RelatedMapping
@@ -358,6 +358,12 @@ class StufMappedResponse(StufResponse):
         else:
             # Plain element value
             return self.stuf_message.get_elm_value(mapping, obj)
+
+    @property
+    @abstractmethod
+    def answer_code(self):
+        """The type of response in the StUF message."""
+        pass  # pragma: no cover
 
     @property
     @abstractmethod

--- a/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
+++ b/src/gobstuf/stuf/brp/response/ingeschrevenpersonen.py
@@ -10,7 +10,8 @@ from gobstuf.stuf.brp.response.filters import (
 
 
 class IngeschrevenpersonenStufResponse(StufMappedResponse):
-    answer_section = 'soapenv:Envelope soapenv:Body BG:npsLa01 BG:antwoord'
+    answer_code = "npsLa01"
+    answer_section = f"soapenv:Envelope soapenv:Body BG:{answer_code} BG:antwoord"
     object_elm = 'BG:object'
 
     # These properties are passed to the filter method of the mapped object
@@ -41,8 +42,10 @@ class IngeschrevenpersonenStufKinderenListResponse(IngeschrevenpersonenStufRespo
     response_filters = [KinderenListResponseFilter]
 
 
-class IngeschrevenpersonenStufHistorieResponse(IngeschrevenpersonenStufResponse):
-    answer_section = 'soapenv:Envelope soapenv:Body BG:npsLa07 BG:antwoord'
+class IngeschrevenpersonenStufHistorieResponse(StufMappedResponse):
+    answer_code = "npsLa07"
+    answer_section = f"soapenv:Envelope soapenv:Body BG:{answer_code} BG:antwoord"
+    object_elm = "BG:object"
 
     response_filters = [VerblijfplaatsHistorieFilter]
 

--- a/src/gobstuf/stuf/brp/response_mapping.py
+++ b/src/gobstuf/stuf/brp/response_mapping.py
@@ -1,4 +1,5 @@
 import datetime
+from collections import defaultdict
 
 from typing import Type, Optional, Union
 from abc import ABC, abstractmethod
@@ -22,6 +23,11 @@ class Mapping(ABC):
     @property
     @abstractmethod
     def mapping(self) -> dict:  # pragma: no cover
+        pass
+
+    @property
+    @abstractmethod
+    def answer_code(self) -> str:  # pragma: no cover
         pass
 
     @property
@@ -67,28 +73,27 @@ class Mapping(ABC):
 
 
 class StufObjectMapping:
-    """Class holding all Mapping objects. Call register() with each Mapping to make the mapping available.
-
-    """
-    mappings = {}
+    """Class holding all Mapping objects. Call register() with each Mapping to make the mapping available."""
+    mappings = defaultdict(dict)
 
     @classmethod
-    def get_for_entity_type(cls, entity_type: str):
-        mapping = cls.mappings.get(entity_type)
-
-        if not mapping:
-            raise Exception(f"Can't find mapping for entity type {entity_type}")
-        return mapping()
+    def get_for_entity_type(cls, answer_code: str, entity_type: str) -> Mapping:
+        try:
+            return cls.mappings[answer_code][entity_type]()
+        except KeyError:
+            raise Exception(f"Can't find mapping for answer/entity type combination: {answer_code} / {entity_type}")
 
     @classmethod
     def register(cls, mapping: Type[Mapping]):
-        cls.mappings[mapping().entity_type] = mapping
+        map_obj = mapping()
+        cls.mappings[map_obj.answer_code] |= {map_obj.entity_type: mapping}
 
 
 class NPSMapping(Mapping):
-    """NPS mapping, for Natuurlijke Personen
-
-    """
+    """NPS mapping, for Natuurlijke Personen."""
+    @property
+    def answer_code(self):
+        return "npsLa01"
 
     @property
     def entity_type(self):
@@ -634,6 +639,10 @@ class RelatedMapping(Mapping):
 class NPSNPSHUWMapping(RelatedMapping):
 
     @property
+    def answer_code(self) -> str:
+        return "npsLa01"
+
+    @property
     def entity_type(self):  # pragma: no cover
         return 'NPSNPSHUW'
 
@@ -784,6 +793,10 @@ class NPSFamilieRelatedMapping(RelatedMapping):
 class NPSNPSOUDMapping(NPSFamilieRelatedMapping):
 
     @property
+    def answer_code(self) -> str:
+        return "npsLa01"
+
+    @property
     def entity_type(self):  # pragma: no cover
         return 'NPSNPSOUD'
 
@@ -808,6 +821,10 @@ StufObjectMapping.register(NPSNPSOUDMapping)
 class NPSNPSKNDMapping(NPSFamilieRelatedMapping):
 
     @property
+    def answer_code(self) -> str:
+        return "npsLa01"
+
+    @property
     def entity_type(self):  # pragma: no cover
         return 'NPSNPSKND'
 
@@ -820,3 +837,17 @@ class NPSNPSKNDMapping(NPSFamilieRelatedMapping):
 
 
 StufObjectMapping.register(NPSNPSKNDMapping)
+
+
+class VerblijfplaatsHistorieMapping(NPSMapping):
+
+    @property
+    def answer_code(self):
+        return "npsLa07"
+
+    @property
+    def related(self):
+        return {}
+
+
+StufObjectMapping.register(VerblijfplaatsHistorieMapping)

--- a/src/tests/stuf/brp/test_base_response.py
+++ b/src/tests/stuf/brp/test_base_response.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock, call
 from datetime import date
+import xml.etree.ElementTree as ET
 
 from flask import app
 
@@ -24,10 +25,12 @@ class StufResponseTest(TestCase):
 
 
 class StufMappedResponseImpl(StufMappedResponse):
+    answer_code = "ANSWER CODE"
     answer_section = 'ANSWER SECTION'
     object_elm = 'OBJECT'
 
     class MockMapping(Mapping):
+        answer_code = "ANS"
         entity_type = 'TST'
         mapping = {
             'attr1': 'XML PATH A',
@@ -70,6 +73,7 @@ class MockWildcardSearchResponseFilter(MagicMock):
 
 
 class StufMappedResponseRelatedImpl(StufMappedResponse):
+    answer_code = "ANSWER CODE"
     answer_section = 'ANSWER SECTION'
     object_elm = 'OBJECT'
 
@@ -79,6 +83,7 @@ class StufMappedResponseRelatedImpl(StufMappedResponse):
 class MappedObjectWrapperTest(TestCase):
     class MockMapping(Mapping):
         entity_type = 'TST'
+        answer_code = "ANS"
         mapping = {
             'A': 'some mapping to A',
             'B': 'some mapping to B',
@@ -215,6 +220,7 @@ class StufMappedResponseTest(TestCase):
 
     def test_sort_embedded_objects(self):
         class MockedMapping(Mapping):
+            answer_code = "ANS"
             entity_type = 'ENT'
             mapping = {}
             related = {}
@@ -235,6 +241,7 @@ class StufMappedResponseTest(TestCase):
     def test_add_embedded_objects(self):
         class MockedMapping(Mapping):
             entity_type = 'ENT'
+            answer_code = "ANS"
             mapping = {}
             related = {
                 'partners': 'SOME PATH TO PARTNERS',
@@ -379,6 +386,7 @@ class StufMappedResponseTest(TestCase):
 
     def test_get_mapped_related_object(self):
         class RelatedMappingImpl(RelatedMapping):
+            answer_code = "ANS"
             entity_type = 'REL'
             mapping = {}
             override_related_filters = {'override': 'this one is overridden'}
@@ -402,6 +410,7 @@ class StufMappedResponseTest(TestCase):
 
     def test_get_mapped_object_related(self):
         class RelatedMappingImpl(RelatedMapping):
+            answer_code = "ANS"
             entity_type = 'REL'
             mapping = {'extra attr': 'attrB'}
 
@@ -423,6 +432,7 @@ class StufMappedResponseTest(TestCase):
     def test_get_mapping(self, mock_get_for_entity_type):
 
         class Impl(StufMappedResponse):
+            answer_code = "ANSWER_CODE"
             answer_section = 'ANSWER SECTION'
             object_elm = 'OBJECT'
 
@@ -433,16 +443,16 @@ class StufMappedResponseTest(TestCase):
         }})
 
         self.assertEqual(mock_get_for_entity_type.return_value, resp._get_mapping(element))
-        mock_get_for_entity_type.assert_called_with('TST')
-
-
-import xml.etree.ElementTree as ET
+        mock_get_for_entity_type.assert_called_with("ANSWER_CODE", 'TST')
 
 
 class TestMappedObject(TestCase):
 
     def test_mapped_object(self):
         class MappedResponse(StufMappedResponse):
+            @property
+            def answer_code(self):
+                pass
             @property
             def answer_section(self):
                 pass

--- a/src/tests/stuf/brp/test_response_mapping.py
+++ b/src/tests/stuf/brp/test_response_mapping.py
@@ -10,11 +10,13 @@ from gobstuf.stuf.brp.response_mapping import (
 class MappingImpl(Mapping):
     mapping = {}
     entity_type = 'TST'
+    answer_code = "code1"
 
 
 class MappingImpl2(Mapping):
     mapping = {}
     entity_type = 'TST2'
+    answer_code = "code2"
 
 
 class TestMapping(TestCase):
@@ -69,15 +71,15 @@ class TestStufObjectMapping(TestCase):
         StufObjectMapping.register(MappingImpl)
         StufObjectMapping.register(MappingImpl2)
 
-        self.assertIsInstance(StufObjectMapping.get_for_entity_type('TST'), MappingImpl)
-        self.assertIsInstance(StufObjectMapping.get_for_entity_type('TST2'), MappingImpl2)
+        self.assertIsInstance(StufObjectMapping.get_for_entity_type("code1", 'TST'), MappingImpl)
+        self.assertIsInstance(StufObjectMapping.get_for_entity_type("code2", 'TST2'), MappingImpl2)
 
         # Should return different instances
-        self.assertNotEqual(StufObjectMapping.get_for_entity_type('TST'),
-                            StufObjectMapping.get_for_entity_type('TST'))
+        self.assertNotEqual(StufObjectMapping.get_for_entity_type("code1", 'TST'),
+                            StufObjectMapping.get_for_entity_type("code1", 'TST'))
 
         with self.assertRaises(Exception):
-            StufObjectMapping.get_for_entity_type('NONEXISTENT')
+            StufObjectMapping.get_for_entity_type('NONEXISTENT', "NONEXISTENT")
 
 
 class TestNPSMapping(TestCase):
@@ -599,6 +601,7 @@ class TestRelatedMapping(TestCase):
 
     def test_filter(self):
         class RelatedMappingImpl(RelatedMapping):
+            answer_code = "ANSCODE"
             entity_type = 'RELMAP'
             mapping = {'D': 'not important'}
             include_related = ['A', 'B']
@@ -665,6 +668,10 @@ class TestNPSNPSHUWMapping(TestCase):
 class TestNPSFamilieRelatedMapping(TestCase):
 
     class NPSFamilieRelatedMappingImpl(NPSFamilieRelatedMapping):
+
+        @property
+        def answer_code(self) -> str:
+            return "fam answer code"
 
         @property
         def entity_type(self):


### PR DESCRIPTION
A mapping can't only be derived from the entity type. A mapping can differ between different answer codes. 
Implemented a structure to hold the mappings per answer code.