### PR TITLE
Add `StufRestViewAsList` to return a list response from single object

### DIFF
--- a/src/gobstuf/rest/brp/views.py
+++ b/src/gobstuf/rest/brp/views.py
@@ -115,23 +115,11 @@ class IngeschrevenpersonenBsnKinderenDetailView(IngeschrevenpersonenBsnView):
 
 
 class IngeschrevenpersonenBsnVerblijfsplaatshistorieListView(StufRestFilterView):
-    def get_not_found_message(self, **kwargs):
-        return f"Verblijfsplaatshistorie niet gevonden voor burgerservicenummer {kwargs['bsn']}."
 
     request_template = IngeschrevenpersonenBsnHistorieStufRequest
     response_template = IngeschrevenpersonenStufHistorieResponse
 
     name = 'verblijfplaatshistorie'
 
-    # For this Class parameters are not required, but if they are used, only certain combinations are valid
-    # Herefore the empty tuple is provided at index 2 of query_parameter_combinations
-    query_parameter_combinations = [
-        ('datumVan', 'datumTotEnMet'),
-        ('peildatum',),
-        ()
-     ]
-
-    optional_query_parameters = []
-
-    def _request_template_parameters(self, **kwargs):
-        return kwargs
+    def get_not_found_message(self, **kwargs):
+        return f"Verblijfsplaatshistorie niet gevonden voor burgerservicenummer {kwargs['bsn']}."

--- a/src/gobstuf/stuf/brp/base_response.py
+++ b/src/gobstuf/stuf/brp/base_response.py
@@ -9,7 +9,7 @@ from xml.etree.ElementTree import Element
 from gobstuf.lib.utils import get_value
 from gobstuf.rest.brp.argument_checks import WILDCARD_CHARS
 from gobstuf.stuf.message import StufMessage
-from gobstuf.stuf.exception import NoStufAnswerException
+from gobstuf.stuf.exception import NoStufAnswerException, NoStufAnswerFilterException
 from gobstuf.stuf.brp.response_mapping import StufObjectMapping, Mapping, RelatedMapping
 
 
@@ -206,11 +206,12 @@ class StufMappedResponse(StufResponse):
         answer_object = self.create_object_from_element(object)
 
         # Filter the response if a response type is defined
-        for filter in self.response_filters_instances:
-            answer_object = filter.filter_response(answer_object)
+        if answer_object is not None:
+            for filter in self.response_filters_instances:
+                answer_object = filter.filter_response(answer_object)
 
         if not answer_object:
-            raise NoStufAnswerException()
+            raise NoStufAnswerFilterException()
 
         return answer_object
 

--- a/src/gobstuf/stuf/exception.py
+++ b/src/gobstuf/stuf/exception.py
@@ -1,2 +1,6 @@
 class NoStufAnswerException(Exception):
     pass
+
+
+class NoStufAnswerFilterException(Exception):
+    pass

--- a/src/tests/stuf/brp/test_base_response.py
+++ b/src/tests/stuf/brp/test_base_response.py
@@ -9,6 +9,7 @@ from gobstuf.stuf.brp.base_response import StufResponse, StufMappedResponse, NoS
     MappedObjectWrapper, RelatedDetailResponseFilter, RelatedListResponseFilter, WildcardSearchResponseFilter, \
     VerblijfplaatsHistorieFilter
 from gobstuf.stuf.brp.response_mapping import RelatedMapping
+from gobstuf.stuf.exception import NoStufAnswerFilterException
 
 
 @patch("gobstuf.stuf.brp.base_response.StufMessage")
@@ -321,7 +322,7 @@ class StufMappedResponseTest(TestCase):
         resp.get_object_elm = MagicMock()
         resp.create_object_from_element = MagicMock(return_value=None)
 
-        with self.assertRaises(NoStufAnswerException):
+        with self.assertRaises(NoStufAnswerFilterException):
             result = resp.get_answer_object()
 
     def test_get_answer_object_related(self):


### PR DESCRIPTION
- Raise different exceptions based on if bsn is found or empty response due to filtering
- Handle exceptions seperately for both cases